### PR TITLE
Allow opting out of request body parsing

### DIFF
--- a/entrypoints/nextjs.ts
+++ b/entrypoints/nextjs.ts
@@ -19,6 +19,13 @@ export type VerifySignaturConfig = {
    * @default 0
    */
   clockTolerance?: number;
+
+  /**
+   * Opt out of request body parsing.
+   *
+   * If this is set to true, req.body will not be set
+   */
+  disableRequestBodyParsing?: boolean;
 };
 export function verifySignature(
   handler: NextApiHandler,
@@ -77,14 +84,16 @@ export function verifySignature(
       return res.end();
     }
 
-    try {
-      if (req.headers["content-type"] === "application/json") {
-        req.body = JSON.parse(body);
-      } else {
+    if (!config?.disableRequestBodyParsing) {
+      try {
+        if (req.headers["content-type"] === "application/json") {
+          req.body = JSON.parse(body);
+        } else {
+          req.body = body;
+        }
+      } catch {
         req.body = body;
       }
-    } catch {
-      req.body = body;
     }
 
     return handler(req, res);


### PR DESCRIPTION
Hello! Thanks so much for your work on this library! 

I was wondering about your rationale for parsing the `req.body` in the Next.js `verifySignature` function. Is it mostly to provide convenience to the end-user? 

I wanted to propose a config option to opt out of this behavior so that the request stream is not consumed. It would help me retain the raw request that I could use for other purposes. 

Would appreciate your feedback. Thank you!