### PR TITLE
RFC: Update receiver.ts public method to return payload event

### DIFF
--- a/pkg/receiver.ts
+++ b/pkg/receiver.ts
@@ -172,6 +172,6 @@ export class Receiver {
       );
     }
 
-    return payload;
+    return body;
   }
 }


### PR DESCRIPTION
**Changes**
- renames the `verify` method to `constructEvent` (similar to stripe's api)
- now returns the payload

**Context**

This is useful to provide storngly-typed objects back to the caller.
E.g. with tRPC (which validates with zod), I can pass that to an input I've defined previously:
```ts
const handler = async (req: NextApiRequest, res: NextApiResponse) => {
  const receiver = new Receiver({
    currentSigningKey: process.env.QSTASH_CURRENT_SIGNING_KEY!,
    nextSigningKey: process.env.QSTASH_NEXT_SIGNING_KEY!,
  });

 // validates but also provides a strongly-typed `event` I can handle just how I expect.
  const event = await receiver.constructEvent(req);

  const ctx = await createTRPCContext({ req, res });
  const caller = appRouter.createCaller(ctx);

  // I've defined the `downloadArticlesOfAssociation` mutation with a zod schema for an input so that I can still rely on my own validation
  return caller.mandate.downloadArticlesOfAssociation({ event });
};
```

NB: The types here are missing, but it would make for a nicer DX imho