### PR TITLE
Add Missing Fields in Requests & Add DLQ Filtering and Batch Cancel API

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -214,6 +214,7 @@ type EventsRequestFilter = {
   state?: State;
   url?: string;
   urlGroup?: string;
+  api?: string;
   scheduleId?: string;
   queueName?: string;
   fromDate?: number; // unix timestamp (ms)

--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -1,15 +1,29 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { sleep } from "bun";
-import { afterAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Client } from "./client";
 
 describe("DLQ", () => {
   const client = new Client({ token: process.env.QSTASH_TOKEN! });
+  const urlGroup = "someUrlGroup";
+
+  beforeAll(async () => {
+    await client.urlGroups.addEndpoints({
+      name: urlGroup,
+      endpoints: [
+        {
+          name: "myEndpoint",
+          url: "https://example.com/789/?asdasd=ooo",
+        },
+      ],
+    });
+  });
 
   afterAll(async () => {
     const dlqLogs = await client.dlq.listMessages();
     await client.dlq.deleteMany({ dlqIds: dlqLogs.messages.map((dlq) => dlq.dlqId) });
+    await client.urlGroups.delete(urlGroup);
   });
 
   test(
@@ -47,6 +61,57 @@ describe("DLQ", () => {
       dlqMessage = dlqLogs.messages.find((dlq) => dlq.messageId === message.messageId);
 
       expect(dlqMessage).toBeUndefined();
+    },
+    { timeout: 20_000 }
+  );
+
+  test(
+    "should filter requests",
+    async () => {
+      const message = await client.publish({
+        url: `https://example.com/123/?asdasd=ooo`, //Any broken link will work
+        retries: 0,
+      });
+
+      await sleep(10_000);
+
+      const result = await client.dlq.listMessages({
+        filter: {
+          messageId: message.messageId,
+        },
+      });
+
+      expect(result.messages.length).toBe(1);
+      expect(result.messages[0].messageId).toBe(message.messageId);
+
+      await client.dlq.delete(result.messages[0].dlqId);
+    },
+    { timeout: 20_000 }
+  );
+
+  test(
+    "should filter requests with urlGroup",
+    async () => {
+      /**
+       * we pass both urlGroup and topicName in our request, which could
+       * fail in the backend. Adding this test to make sure that
+       */
+      const message = await client.publish({
+        urlGroup: urlGroup,
+        retries: 0,
+      });
+
+      await sleep(10_000);
+
+      const result = await client.dlq.listMessages({
+        filter: {
+          urlGroup: urlGroup,
+        },
+      });
+
+      expect(result.messages.length).toBe(1);
+      expect(result.messages[0].messageId).toBe(message[0].messageId);
+      await client.dlq.delete(result.messages[0].dlqId);
     },
     { timeout: 20_000 }
   );

--- a/src/client/dlq.ts
+++ b/src/client/dlq.ts
@@ -2,7 +2,32 @@ import type { Requester } from "./http";
 import type { Message } from "./messages";
 
 type DlqMessage = Message & {
+  /**
+   * The unique id within the DLQ
+   */
   dlqId: string;
+
+  /**
+   * The HTTP status code of the last failed delivery attempt
+   */
+  responseStatus?: number;
+
+  /**
+   * The response headers of the last failed delivery attempt
+   */
+  responseHeader?: Record<string, string[]>;
+
+  /**
+   * The response body of the last failed delivery attempt if it is
+   * composed of UTF-8 characters only, `None` otherwise.
+   */
+  responseBody?: string;
+
+  /**
+   * The base64 encoded response body of the last failed delivery attempt
+   * if the response body contains non-UTF-8 characters, `None` otherwise.
+   */
+  responseBodyBase64?: string;
 };
 
 export type DlqMessagePayload = Omit<DlqMessage, "urlGroup"> & { topicName: string };

--- a/src/client/messages.test.ts
+++ b/src/client/messages.test.ts
@@ -1,9 +1,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { Client } from "./client";
 
 describe("Messages", () => {
   const client = new Client({ token: process.env.QSTASH_TOKEN! });
+
+  beforeAll(async () => {
+    await client.messages.deleteAll();
+  });
 
   test(
     "should send message, cancel it then verify cancel",
@@ -41,6 +45,47 @@ describe("Messages", () => {
       const verifiedMessage = await client.messages.get(message.messageId);
       expect(verifiedMessage.messageId).toBeTruthy();
       await client.messages.delete(message.messageId);
+    },
+    { timeout: 20_000 }
+  );
+
+  test(
+    "should delete many and all",
+    async () => {
+      const messages = await client.batchJSON([
+        {
+          url: `https://example.com`,
+          body: { hello: "world" },
+          timeout: 90,
+          delay: 10,
+        },
+        {
+          url: `https://example.com`,
+          body: { hello: "world" },
+          timeout: 90,
+          delay: 10,
+        },
+        {
+          url: `https://example.com`,
+          body: { hello: "world" },
+          timeout: 90,
+          delay: 10,
+        },
+      ]);
+
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+      expect(messages.length).toBe(3);
+
+      const deleted = await client.messages.deleteMany([
+        messages[0].messageId,
+        messages[1].messageId,
+      ]);
+
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+      expect(deleted).toBe(2);
+
+      const deletedAll = await client.messages.deleteAll();
+      expect(deletedAll).toBe(1);
     },
     { timeout: 20_000 }
   );

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -17,6 +17,17 @@ export type Message = {
   url: string;
 
   /**
+   * The endpoint name of the message if the endpoint is given a
+   * name within the url group.
+   */
+  endpointName?: string;
+
+  /**
+   * The api name if this message was sent to an api
+   */
+  api?: string;
+
+  /**
    * The http method used to deliver the message
    */
   method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
@@ -30,6 +41,12 @@ export type Message = {
    * The http body sent to your API
    */
   body?: string;
+
+  /**
+   * The base64 encoded body if the body contains non-UTF-8 characters,
+   * `None` otherwise.
+   */
+  bodyBase64?: string;
 
   /**
    * Maxmimum number of retries.
@@ -60,6 +77,16 @@ export type Message = {
    * The queue name if this message was sent to a queue.
    */
   queueName?: string;
+
+  /**
+   * The scheduleId of the message if the message is triggered by a schedule
+   */
+  scheduleId?: string;
+
+  /**
+   * IP address of the publisher of this message
+   */
+  callerIp?: string;
 };
 
 export type MessagePayload = Omit<Message, "urlGroup"> & { topicName: string };

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -123,4 +123,22 @@ export class Messages {
       parseResponseAsJson: false,
     });
   }
+
+  public async deleteMany(messageIds: string[]): Promise<number> {
+    const result = (await this.http.request({
+      method: "DELETE",
+      path: ["v2", "messages"],
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messageIds }),
+    })) as { cancelled: number };
+    return result.cancelled;
+  }
+
+  public async deleteAll(): Promise<number> {
+    const result = (await this.http.request({
+      method: "DELETE",
+      path: ["v2", "messages"],
+    })) as { cancelled: number };
+    return result.cancelled;
+  }
 }

--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -10,10 +10,12 @@ export type Schedule = {
   method: string;
   header?: Record<string, string[]>;
   body?: string;
+  bodyBase64?: string;
   retries: number;
   delay?: number;
   callback?: string;
   failureCallback?: string;
+  callerIp?: string;
   isPaused: true | undefined;
 };
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -9,6 +9,8 @@ export type Event = {
   url: string;
   urlGroup?: string;
   endpointName?: string;
+  header?: Record<string, string>;
+  body?: string; // base64 encoded
 };
 
 export type EventPayload = Omit<Event, "urlGroup"> & { topicName: string };


### PR DESCRIPTION
Updating Qstash JS with the recent updates to backend.

This pr includes the following changes as @mdumandag listed:

1. [1e6e690](https://github.com/upstash/qstash-js/pull/114/commits/1e6e69099e0efb8a99083c99a4a4b35ab428956e): message type has missing fields (like endpoint, api, caller ip, bodyBase64 etc.)
2. [bc1c164](https://github.com/upstash/qstash-js/pull/114/commits/bc1c1646dd5d367ffbd701e13cd751dc156906c9): dlq message type has missing fields (like response status, response headers etc.)
3. [d4fc931](https://github.com/upstash/qstash-js/pull/114/commits/d4fc931f7e086f79bb74cf23992e7876a55af67e): dlq list method missing filter and count (the python client has a pending pr for it) https://github.com/upstash/qstash-py/pull/21
4. [60e89d5](https://github.com/upstash/qstash-js/pull/114/commits/60e89d53572a0e69c4bc444645099c118c4dfe90): event filter missing api field
5. [5c01b1c](https://github.com/upstash/qstash-js/pull/114/commits/5c01b1c8a011d9275a43a92a2de7db744560bd38): event list response missing some fields (like api, queue name, schedule id, and fields in this
    - PR https://github.com/upstash/qstash-server/pull/298 (they are not even implemented in python client yet, i will send a pr for it))
    - https://github.com/upstash/qstash-py/pull/23
7. [d0f588f](https://github.com/upstash/qstash-js/pull/114/commits/d0f588f019c593d0cd1eb101e64cd6d8f6340786): scheduele type missing fields (like bodyBase64 and caller ip)
8. [dd93920](https://github.com/upstash/qstash-js/pull/114/commits/dd93920a14248fb3d473c56e2f8c59b7aaebce83): missing batch cancel apis (the python client has a pending pr for it) https://github.com/upstash/qstash-py/pull/22 