### PR TITLE
Workflow: verify requests in workflow

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -10,6 +10,7 @@ import type { BodyInit, Event, GetEventsPayload, HeadersInit, State } from "./ty
 import { UrlGroups } from "./url-groups";
 import { getRequestPath, prefixHeaders, processHeaders } from "./utils";
 import { Workflow } from "./workflow/workflow";
+import type { Receiver } from "../receiver";
 
 type ClientConfig = {
   /**
@@ -437,8 +438,8 @@ export class Client {
     };
   }
 
-  public async workflow(request: Request) {
-    return await Workflow.createWorkflow(request, this);
+  public async workflow(request: Request, receiver?: Receiver) {
+    return await Workflow.createWorkflow(request, this, receiver);
   }
 }
 


### PR DESCRIPTION
Add request verificaton to workflow. Basically every request except the first one are validated to make sure that they are coming from QStash. The first request will be coming from the user so it's not validated.

Note that the functions and their parameters are internal. We will offer a simpler API to the user like

```ts
const options: {
  receiver?: Receiver
} = {
  // ...
};

client.serve(async (context) => {
  //  workflow steps...
}, options);
```

passing options will be optional, if receiver is not passed, it will be created from the env variables, if the env variables are not set, we will print a warning message `Warning: QStash Workflow wasn't passed a receiver to verify the requests.` as in this PR.