### PR TITLE
fix: token pass, baseUrl strip and typo

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -214,6 +214,7 @@ export type QueueRequest = {
 
 export class Client {
   public http: Requester;
+  private token: string;
 
   public constructor(config: ClientConfig) {
     this.http = new HttpClient({
@@ -221,6 +222,7 @@ export class Client {
       baseUrl: config.baseUrl ? config.baseUrl.replace(/\/$/, "") : "https://qstash.upstash.io",
       authorization: `Bearer ${config.token}`,
     });
+    this.token = config.token;
   }
 
   /**
@@ -274,7 +276,7 @@ export class Client {
    * Call the create or prompt methods
    */
   public chat(): Chat {
-    return new Chat(this.http);
+    return new Chat(this.http, this.token);
   }
 
   public async publish<TRequest extends PublishRequest>(

--- a/src/client/llm/chat.test.ts
+++ b/src/client/llm/chat.test.ts
@@ -259,7 +259,7 @@ describe("Test Qstash chat with third party LLMs", () => {
     { timeout: 30_000, retry: 3 }
   );
 
-  test("should publish with llm api", async () => {
+  test("should publish with llm api - todo", async () => {
     const result = await client.publishJSON({
       api: { name: "llm", provider: openai({ token: process.env.OPENAI_API_KEY! }) },
       body: {

--- a/src/client/llm/providers.test.ts
+++ b/src/client/llm/providers.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { custom } from "./providers";
+
+describe("Provider helpers", () => {
+  test("should trim /chat/completion/if you user fullUrl", () => {
+    expect(custom({ baseUrl: "https://api.together.xyz/chat/completions", token: "xxx" })).toEqual({
+      baseUrl: "https://api.together.xyz",
+      token: "xxx",
+      owner: "custom",
+    });
+  });
+  test("should trim /v1/chat/completion/if you user fullUrl", () => {
+    expect(
+      custom({ baseUrl: "https://api.together.xyz/v1/chat/completions", token: "xxx" })
+    ).toEqual({ baseUrl: "https://api.together.xyz", token: "xxx", owner: "custom" });
+  });
+});

--- a/src/client/llm/providers.ts
+++ b/src/client/llm/providers.ts
@@ -9,11 +9,10 @@ const upstash = (): {
   baseUrl: "https://qstash.upstash.io/llm";
   token: string;
 } => {
-  if (!process.env.QSTASH_TOKEN) throw new Error("QSTASH_TOKEN cannot be empty or undefined!");
   return {
     owner: "upstash",
     baseUrl: "https://qstash.upstash.io/llm",
-    token: process.env.QSTASH_TOKEN,
+    token: "",
   };
 };
 

--- a/src/client/llm/providers.ts
+++ b/src/client/llm/providers.ts
@@ -32,7 +32,11 @@ const custom = ({
   token: string;
   baseUrl: string;
 }): { owner: "custom"; baseUrl: string; token: string } => {
-  return { token, owner: "custom", baseUrl };
+  const trimmedBaseUrl = baseUrl.replace(/\/(v1\/)?chat\/completions$/, ""); // Will trim /v1/chat/completions and /chat/completions
+  return {
+    token,
+    owner: "custom",
+    baseUrl: trimmedBaseUrl,
+  };
 };
-
 export { custom, openai, upstash };

--- a/src/client/llm/utils.ts
+++ b/src/client/llm/utils.ts
@@ -29,7 +29,7 @@ export function appendLLMOptionsIfNeeded<
     if (!provider?.baseUrl) throw new Error("baseUrl cannot be empty or undefined!");
     if (!provider.token) throw new Error("token cannot be empty or undefined!");
 
-    request.url = `${provider.baseUrl}/v1/chat/completion`;
+    request.url = `${provider.baseUrl}/v1/chat/completions`;
     headers.set("Authorization", `Bearer ${provider.token}`);
   }
 }


### PR DESCRIPTION
This PR adds:

- Passes token directly to chat(), instead of implicit process.env.QSTASH_TOKEN
- Fixes /completion typo to /completions
- Trims baseUrl if user passes fullUrl