### PR TITLE
fix: add topic back

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -158,6 +158,7 @@ export type PublishRequest<TBody = BodyInit> = {
       url: string;
       urlGroup?: never;
       api?: never;
+      topic?: never;
     }
   | {
       url?: never;
@@ -166,6 +167,7 @@ export type PublishRequest<TBody = BodyInit> = {
        */
       urlGroup: string;
       api?: never;
+      topic?: never;
     }
   | {
       url?: string;
@@ -174,6 +176,16 @@ export type PublishRequest<TBody = BodyInit> = {
        * The api endpoint the request should be sent to.
        */
       api: { name: "llm"; provider?: ProviderReturnType };
+      topic?: never;
+    }
+  | {
+      url?: never;
+      urlGroup?: never;
+      api: never;
+      /**
+       * Deprecated. The topic the message should be sent to. Same as urlGroup
+       */
+      topic?: string;
     }
 );
 
@@ -195,6 +207,7 @@ type EventsRequestFilter = {
   state?: State;
   url?: string;
   urlGroup?: string;
+  topicName?: string;
   api?: string;
   scheduleId?: string;
   queueName?: string;
@@ -232,6 +245,17 @@ export class Client {
    */
   public get urlGroups(): UrlGroups {
     return new UrlGroups(this.http);
+  }
+
+  /**
+   * Deprecated. Use urlGroups instead.
+   *
+   * Access the topic API.
+   *
+   * Create, read, update or delete topics.
+   */
+  public get topics(): UrlGroups {
+    return this.urlGroups;
   }
 
   /**
@@ -404,8 +428,10 @@ export class Client {
       if (typeof value === "number" && value < 0) {
         continue;
       }
-      // eslint-disable-next-line unicorn/no-typeof-undefined
-      if (typeof value !== "undefined") {
+      if (key === "urlGroup") {
+        query.topicName = value.toString();
+        // eslint-disable-next-line unicorn/no-typeof-undefined
+      } else if (typeof value !== "undefined") {
         query[key] = value.toString();
       }
     }

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -12,6 +12,11 @@ export type Message = {
   urlGroup?: string;
 
   /**
+   * Deprecated. The topic name if this message was sent to a urlGroup. Use urlGroup instead
+   */
+  topicName?: string;
+
+  /**
    * The url where this message is sent to.
    */
   url: string;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -8,6 +8,7 @@ export type Event = {
   error?: string;
   url: string;
   urlGroup?: string;
+  topicName?: string;
   endpointName?: string;
   header?: Record<string, string>;
   body?: string; // base64 encoded

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -62,6 +62,8 @@ export function processHeaders(request: PublishRequest) {
   return headers;
 }
 
-export function getRequestPath(request: Pick<PublishRequest, "url" | "urlGroup" | "api">): string {
-  return request.url ?? request.urlGroup ?? `api/${request.api?.name}`;
+export function getRequestPath(
+  request: Pick<PublishRequest, "url" | "urlGroup" | "api" | "topic">
+): string {
+  return request.url ?? request.urlGroup ?? request.topic ?? `api/${request.api?.name}`;
 }


### PR DESCRIPTION
when we renamed topic as url group, we made a backwards incompatible change. Adding topic back and marking it as deprecated to remove later.

addresses https://github.com/upstash/qstash-js/pull/109#issuecomment-2212551870