### PR TITLE
Workflow: Add Step Name & Step Name Checks

### DIFF
--- a/examples/workflow/nextjs/app/northStar/route.ts
+++ b/examples/workflow/nextjs/app/northStar/route.ts
@@ -60,7 +60,7 @@ export const POST = serve<Invoice>({
       await context.sleep("retrySleep", 2)
     }
     await context.run("paymentFailed", async () => {
-      console.log(`northStarSimple field permenantly with input ${JSON.stringify(context.requestPayload)}`);
+      console.log(`northStarSimple failed permenantly with input ${JSON.stringify(context.requestPayload)}`);
       return true
     })
   }

--- a/examples/workflow/nextjs/app/northStarSimple/route.ts
+++ b/examples/workflow/nextjs/app/northStarSimple/route.ts
@@ -55,7 +55,7 @@ export const POST = serve<Invoice>({
       await context.sleep("retrySleep", 2)
     }
     await context.run("paymentFailed", async () => {
-      console.log(`northStarSimple field permenantly with input ${JSON.stringify(context.requestPayload)}`);
+      console.log(`northStarSimple failed permenantly with input ${JSON.stringify(context.requestPayload)}`);
       return true
     })
   }

--- a/examples/workflow/nextjs/app/sleepWithoutAwait/route.ts
+++ b/examples/workflow/nextjs/app/sleepWithoutAwait/route.ts
@@ -61,7 +61,7 @@ export const POST = serve<Invoice>({
       await context.sleep("retrySleep", 2)
     }
     await context.run("paymentFailed", async () => {
-      console.log(`northStarSimple field permenantly with input ${JSON.stringify(context.requestPayload)}`);
+      console.log(`northStarSimple failed permenantly with input ${JSON.stringify(context.requestPayload)}`);
       return true
     })
   }

--- a/examples/workflow/nuxt/server/api/northStar.ts
+++ b/examples/workflow/nuxt/server/api/northStar.ts
@@ -60,7 +60,7 @@ export default serve<Invoice>({
       await context.sleep("retrySleep", 2)
     }
     await context.run("paymentFailed", async () => {
-      console.log(`northStarSimple field permenantly with input ${JSON.stringify(context.requestPayload)}`);
+      console.log(`northStarSimple failed permenantly with input ${JSON.stringify(context.requestPayload)}`);
       return true
     })
   }

--- a/examples/workflow/nuxt/server/api/northStarSimple.ts
+++ b/examples/workflow/nuxt/server/api/northStarSimple.ts
@@ -55,7 +55,7 @@ export default serve<Invoice>({
       await context.sleep("retrySleep", 2)
     }
     await context.run("paymentFailed", async () => {
-      console.log(`northStarSimple field permenantly with input ${JSON.stringify(context.requestPayload)}`);
+      console.log(`northStarSimple failed permenantly with input ${JSON.stringify(context.requestPayload)}`);
       return true
     })
   }

--- a/examples/workflow/nuxt/server/api/sleepWithoutAwait.ts
+++ b/examples/workflow/nuxt/server/api/sleepWithoutAwait.ts
@@ -61,7 +61,7 @@ export default serve<Invoice>({
       await context.sleep("retrySleep", 2)
     }
     await context.run("paymentFailed", async () => {
-      console.log(`northStarSimple field permenantly with input ${JSON.stringify(context.requestPayload)}`);
+      console.log(`northStarSimple failed permenantly with input ${JSON.stringify(context.requestPayload)}`);
       return true
     })
   }

--- a/examples/workflow/solidjs/src/routes/northStar.ts
+++ b/examples/workflow/solidjs/src/routes/northStar.ts
@@ -59,7 +59,7 @@ export const POST = serve<Invoice>({
       await context.sleep("retrySleep", 2)
     }
     await context.run("paymentFailed", async () => {
-      console.log(`northStarSimple field permenantly with input ${JSON.stringify(context.requestPayload)}`);
+      console.log(`northStarSimple failed permenantly with input ${JSON.stringify(context.requestPayload)}`);
       return true
     })
   }

--- a/examples/workflow/solidjs/src/routes/northStarSimple.ts
+++ b/examples/workflow/solidjs/src/routes/northStarSimple.ts
@@ -54,7 +54,7 @@ export const POST = serve<Invoice>({
       await context.sleep("retrySleep", 2)
     }
     await context.run("paymentFailed", async () => {
-      console.log(`northStarSimple field permenantly with input ${JSON.stringify(context.requestPayload)}`);
+      console.log(`northStarSimple failed permenantly with input ${JSON.stringify(context.requestPayload)}`);
       return true
     })
   }

--- a/examples/workflow/solidjs/src/routes/sleepWithoutAwait.ts
+++ b/examples/workflow/solidjs/src/routes/sleepWithoutAwait.ts
@@ -60,7 +60,7 @@ export const POST = serve<Invoice>({
       await context.sleep("retrySleep", 2)
     }
     await context.run("paymentFailed", async () => {
-      console.log(`northStarSimple field permenantly with input ${JSON.stringify(context.requestPayload)}`);
+      console.log(`northStarSimple failed permenantly with input ${JSON.stringify(context.requestPayload)}`);
       return true
     })
   }

--- a/examples/workflow/sveltekit/src/routes/northStar/+server.ts
+++ b/examples/workflow/sveltekit/src/routes/northStar/+server.ts
@@ -62,7 +62,7 @@ export const POST = serve<Invoice>({
       await context.sleep("retrySleep", 2)
     }
     await context.run("paymentFailed", async () => {
-      console.log(`northStarSimple field permenantly with input ${JSON.stringify(context.requestPayload)}`);
+      console.log(`northStarSimple failed permenantly with input ${JSON.stringify(context.requestPayload)}`);
       return true
     })
   },

--- a/examples/workflow/sveltekit/src/routes/northStarSimple/+server.ts
+++ b/examples/workflow/sveltekit/src/routes/northStarSimple/+server.ts
@@ -56,7 +56,7 @@ export const POST = serve<Invoice>({
       await context.sleep("retrySleep", 2)
     }
     await context.run("paymentFailed", async () => {
-      console.log(`northStarSimple field permenantly with input ${JSON.stringify(context.requestPayload)}`);
+      console.log(`northStarSimple failed permenantly with input ${JSON.stringify(context.requestPayload)}`);
       return true
     })
   },

--- a/examples/workflow/sveltekit/src/routes/sleepWithoutAwait/+server.ts
+++ b/examples/workflow/sveltekit/src/routes/sleepWithoutAwait/+server.ts
@@ -62,7 +62,7 @@ export const POST = serve<Invoice>({
       await context.sleep("retrySleep", 2)
     }
     await context.run("paymentFailed", async () => {
-      console.log(`northStarSimple field permenantly with input ${JSON.stringify(context.requestPayload)}`);
+      console.log(`northStarSimple failed permenantly with input ${JSON.stringify(context.requestPayload)}`);
       return true
     })
   },

--- a/src/client/workflow/context.ts
+++ b/src/client/workflow/context.ts
@@ -129,6 +129,14 @@ export class WorkflowContext<TInitialPayload = unknown> {
     const versionHeader = request.headers.get(WORKFLOW_PROTOCOL_VERSION_HEADER);
     const isFirstInvocation = !versionHeader;
 
+    // if it's not the first invocation, verify that the workflow protocal version is correct
+    if (!isFirstInvocation && versionHeader !== WORKFLOW_PROTOCOL_VERSION) {
+      throw new QstashWorkflowError(
+        `Incompatible workflow sdk protocol version. Expected ${WORKFLOW_PROTOCOL_VERSION},` +
+          ` got ${versionHeader} from the request.`
+      );
+    }
+
     // get workflow id
     const workflowId = isFirstInvocation
       ? `wf${nanoid()}`

--- a/src/client/workflow/steps.ts
+++ b/src/client/workflow/steps.ts
@@ -9,7 +9,7 @@ import type { AsyncStepFunction, Step, StepType } from "./types";
  */
 export abstract class BaseLazyStep<TResult = unknown> {
   public readonly stepName;
-  public stepType!: StepType; // will be set in the subclasses
+  public abstract readonly stepType: StepType; // will be set in the subclasses
   constructor(stepName: string) {
     this.stepName = stepName;
   }
@@ -38,11 +38,11 @@ export abstract class BaseLazyStep<TResult = unknown> {
  */
 export class LazyFunctionStep<TResult = unknown> extends BaseLazyStep<TResult> {
   private readonly stepFunction: AsyncStepFunction<TResult>;
+  stepType: StepType = "Run";
 
   constructor(stepName: string, stepFunction: AsyncStepFunction<TResult>) {
     super(stepName);
     this.stepFunction = stepFunction;
-    this.stepType = "Run";
   }
 
   public getPlanStep(concurrent: number, targetStep: number): Step<undefined> {
@@ -76,11 +76,11 @@ export class LazyFunctionStep<TResult = unknown> extends BaseLazyStep<TResult> {
  */
 export class LazySleepStep extends BaseLazyStep {
   private readonly sleep: number;
+  stepType: StepType = "SleepFor";
 
   constructor(stepName: string, sleep: number) {
     super(stepName);
     this.sleep = sleep;
-    this.stepType = "SleepFor";
   }
 
   public getPlanStep(concurrent: number, targetStep: number): Step<undefined> {
@@ -115,11 +115,11 @@ export class LazySleepStep extends BaseLazyStep {
  */
 export class LazySleepUntilStep extends BaseLazyStep {
   private readonly sleepUntil: number;
+  stepType: StepType = "SleepUntil";
 
   constructor(stepName: string, sleepUntil: number) {
     super(stepName);
     this.sleepUntil = sleepUntil;
-    this.stepType = "SleepUntil";
   }
 
   public getPlanStep(concurrent: number, targetStep: number): Step<undefined> {

--- a/src/client/workflow/types.ts
+++ b/src/client/workflow/types.ts
@@ -1,9 +1,12 @@
 import type { Client } from "../client";
 import type { WorkflowContext } from "./context";
 
+export type StepType = "Initial" | "Run" | "SleepFor" | "SleepUntil";
+
 export type Step<TResult = unknown> = {
   stepId: number;
   stepName: string;
+  stepType: StepType;
   out?: TResult;
   sleepFor?: number;
   sleepUntil?: number;

--- a/src/client/workflow/workflow-parser.ts
+++ b/src/client/workflow/workflow-parser.ts
@@ -50,6 +50,7 @@ export const parsePayload = (rawPayload: string) => {
   const initialStep: Step = {
     stepId: 0,
     stepName: "init",
+    stepType: "Initial",
     out: initialPayload,
     concurrent: 1,
     targetStep: 0,


### PR DESCRIPTION
### Step Name & Type Checks

This PR adds `stepType` field to `Step` (see 1e7793e3ed434c8b7f2f2156e91076f6ef8df401) and adds several checks which use `validateStep` & `validateParallelSteps` methods for verifying that the steps coming in the request are the same as the ones we expect (see 11890481573f4dc1dd313a623575a81e0577737f).

Additionally, we check if the Workflow protocol version in `src/client/workflow/context.ts`.