### PR TITLE
Workflow: add third party calls

### DIFF
--- a/examples/workflow/nextjs/app/call-endpoint/route.ts
+++ b/examples/workflow/nextjs/app/call-endpoint/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const GET = async (request: NextRequest) => {
+  return new NextResponse("returning GET result", {status: 200})
+}
+
+export const POST = async (request: NextRequest) => {
+  const payload = await request.json()
+  return new NextResponse(`returning POST result with payload: '${payload}'`, {status: 200})
+}

--- a/examples/workflow/nextjs/app/call/route.ts
+++ b/examples/workflow/nextjs/app/call/route.ts
@@ -1,0 +1,31 @@
+
+import { serve } from "@upstash/qstash/workflow/nextjs";
+
+const someWork = (input: string) => {
+  return `processed '${JSON.stringify(input)}'`
+}
+
+export const POST = serve<string>({
+  routeFunction: async context => {
+    const input = context.requestPayload
+
+    const result1 = await context.run("step1", async () => {
+      const output = someWork(input)
+      console.log("step 1 input", input, "output", output)
+      return output
+    });
+
+    const getResult = await context.call<string>("get call", `${context.url}-endpoint`, "GET")
+
+    const result2 = await context.run("step2", async () => {
+      console.log("get result:", getResult);
+      return someWork(getResult)
+    })
+
+    const postResult = await context.call<string>("post call", `${context.url}-endpoint`, "POST", "my-payload")
+
+    const result3 = await context.run("step3", async () => {
+      console.log("post result:", postResult)
+    });
+  }
+})

--- a/examples/workflow/nextjs/app/page.tsx
+++ b/examples/workflow/nextjs/app/page.tsx
@@ -12,7 +12,7 @@ export default function Home() {
   const search = searchParams.get('function');
   const [route, setRoute] = useState(search ?? "path");
 
-  const routes = ['path', 'sleep', 'sleepWithoutAwait', 'northStarSimple', 'northStar'];
+  const routes = ['path', 'sleep', 'sleepWithoutAwait', 'northStarSimple', 'northStar', 'call'];
 
   const handleSend = async () => {
     setLoading(true);

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -6,7 +6,7 @@ import { appendLLMOptionsIfNeeded } from "./llm/utils";
 import { Messages } from "./messages";
 import { Queue } from "./queue";
 import { Schedules } from "./schedules";
-import type { BodyInit, Event, GetEventsPayload, HeadersInit, State } from "./types";
+import type { BodyInit, Event, GetEventsPayload, HeadersInit, HTTPMethods, State } from "./types";
 import { UrlGroups } from "./url-groups";
 import { getRequestPath, prefixHeaders, processHeaders } from "./utils";
 
@@ -137,7 +137,7 @@ export type PublishRequest<TBody = BodyInit> = {
    *
    * @default `POST`
    */
-  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  method?: HTTPMethods;
 
   /**
    * The HTTP timeout value to use while calling the destination URL.

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -5,7 +5,7 @@ import {
   QstashChatRatelimitError,
   QstashDailyRatelimitError,
 } from "./error";
-import type { BodyInit, HeadersInit, RequestOptions } from "./types";
+import type { BodyInit, HeadersInit, HTTPMethods, RequestOptions } from "./types";
 import type { ChatCompletionChunk } from "./llm/types";
 
 export type UpstashRequest = {
@@ -33,7 +33,7 @@ export type UpstashRequest = {
   /**
    * A string to set request's method.
    */
-  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  method?: HTTPMethods;
 
   query?: Record<string, string | number | boolean | undefined>;
 

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -1,4 +1,5 @@
 import type { Requester } from "./http";
+import type { HTTPMethods } from "./types";
 
 export type Message = {
   /**
@@ -35,7 +36,7 @@ export type Message = {
   /**
    * The http method used to deliver the message
    */
-  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  method?: HTTPMethods;
 
   /**
    * The http headers sent along with the message to your API.

--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -1,6 +1,6 @@
 import { prefixHeaders } from "./utils";
 import type { Requester } from "./http";
-import type { BodyInit, HeadersInit } from "./types";
+import type { BodyInit, HeadersInit, HTTPMethods } from "./types";
 
 export type Schedule = {
   scheduleId: string;
@@ -85,7 +85,7 @@ export type CreateScheduleRequest = {
    *
    * @default `POST`
    */
-  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  method?: HTTPMethods;
 
   /**
    * Specify a cron expression to repeatedly send this message to the destination.

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,5 +1,7 @@
 export type State = "CREATED" | "ACTIVE" | "DELIVERED" | "ERROR" | "RETRY" | "FAILED";
 
+export type HTTPMethods = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+
 export type Event = {
   time: number;
   state: State;

--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -1,7 +1,7 @@
 import { QstashWorkflowAbort, QstashWorkflowError } from "../error";
 import type { WorkflowContext } from "./context";
-import type { AsyncStepFunction, ParallelCallState, Step } from "./types";
-import { LazyFunctionStep, LazySleepStep, LazySleepUntilStep, type BaseLazyStep } from "./steps";
+import type { ParallelCallState, Step } from "./types";
+import { type BaseLazyStep } from "./steps";
 
 export class AutoExecutor {
   private context: WorkflowContext;
@@ -17,42 +17,6 @@ export class AutoExecutor {
   }
 
   /**
-   * Adds a sleep step
-   *
-   * @param stepName
-   * @param sleep duration to sleep in seconds
-   * @returns
-   */
-  public async addSleepStep(stepName: string, sleep: number) {
-    return await this.addStep(new LazySleepStep(stepName, sleep));
-  }
-
-  /**
-   * Adds a sleepUntil step
-   *
-   * @param stepName
-   * @param sleepUntil unix timestamp to wait until (in seconds)
-   * @returns
-   */
-  public async addSleepUntilStep(stepName: string, sleepUntil: number) {
-    return await this.addStep(new LazySleepUntilStep(stepName, sleepUntil));
-  }
-
-  /**
-   * Adds an execution step
-   *
-   * @param stepName
-   * @param stepFunction function to execute
-   * @returns
-   */
-  public async addFunctionStep<TResult>(
-    stepName: string,
-    stepFunction: AsyncStepFunction<TResult>
-  ) {
-    return await this.addStep<TResult>(new LazyFunctionStep(stepName, stepFunction));
-  }
-
-  /**
    * Adds the step function to the list of step functions to run in
    * parallel. After adding the function, defers the execution, so
    * that if there is another step function to be added, it's also
@@ -65,7 +29,7 @@ export class AutoExecutor {
    * @param stepInfo step plan to add
    * @returns result of the step function
    */
-  private async addStep<TResult>(stepInfo: BaseLazyStep<TResult>) {
+  public async addStep<TResult>(stepInfo: BaseLazyStep<TResult>) {
     this.stepCount += 1;
 
     const lazyStepList = this.activeLazyStepList ?? [];
@@ -292,11 +256,14 @@ export class AutoExecutor {
 
     await this.context.client.batchJSON(
       steps.map((singleStep) => {
+        const headers = singleStep.callHeaders;
+        const contentType = headers ? headers["Content-Type"] : undefined;
         return {
-          headers: this.context.getHeaders("false"),
-          method: "POST",
-          body: JSON.stringify(singleStep),
-          url: this.context.url,
+          headers: this.context.getHeaders("false", singleStep, contentType),
+          // if the call parameters are set, they overwrite defaults
+          method: singleStep.callMethod ?? "POST",
+          body: singleStep.callBody ?? singleStep,
+          url: singleStep.callUrl ?? this.context.url,
           notBefore: singleStep.sleepUntil,
           delay: singleStep.sleepFor,
         };

--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -2,6 +2,7 @@ import { QstashWorkflowAbort, QstashWorkflowError } from "../error";
 import type { WorkflowContext } from "./context";
 import type { ParallelCallState, Step } from "./types";
 import { type BaseLazyStep } from "./steps";
+import { getHeaders } from "./workflow-requests";
 
 export class AutoExecutor {
   private context: WorkflowContext;
@@ -264,7 +265,7 @@ export class AutoExecutor {
             // handleThirdPartyCallResult method sends the result of the third
             // party call to QStash.
             {
-              headers: this.context.getHeaders("false", singleStep),
+              headers: getHeaders("false", this.context.workflowId, this.context.url, singleStep),
               method: singleStep.callMethod,
               body: singleStep.callBody,
               url: singleStep.callUrl,
@@ -273,7 +274,7 @@ export class AutoExecutor {
             // endpoint (context.url) as URL when calling QStash. QStash
             // calls us back with the updated steps list.
             {
-              headers: this.context.getHeaders("false", singleStep),
+              headers: getHeaders("false", this.context.workflowId, this.context.url, singleStep),
               method: "POST",
               body: singleStep,
               url: this.context.url,

--- a/src/client/workflow/constants.ts
+++ b/src/client/workflow/constants.ts
@@ -3,3 +3,5 @@ export const WORKFLOW_INIT_HEADER = "Upstash-Workflow-Init";
 
 export const WORKFLOW_PROTOCOL_VERSION = "1";
 export const WORKFLOW_PROTOCOL_VERSION_HEADER = "Upstash-Workflow-Sdk-Version";
+
+export const DEFAULT_CONTENT_TYPE = "application/json";

--- a/src/client/workflow/context.ts
+++ b/src/client/workflow/context.ts
@@ -1,15 +1,15 @@
-import type { AsyncStepFunction, InitialPayloadParser, Step } from "./types";
-import { nanoid } from "nanoid";
+import { type AsyncStepFunction, type Step } from "./types";
 import {
+  DEFAULT_CONTENT_TYPE,
   WORKFLOW_ID_HEADER,
   WORKFLOW_INIT_HEADER,
   WORKFLOW_PROTOCOL_VERSION,
   WORKFLOW_PROTOCOL_VERSION_HEADER,
 } from "./constants";
-import { QstashWorkflowError } from "../error";
-import * as WorkflowParser from "./workflow-parser";
 import type { Client } from "../client";
 import { AutoExecutor } from "./auto-executor";
+import { LazyCallStep, LazyFunctionStep, LazySleepStep, LazySleepUntilStep } from "./steps";
+import type { HTTPMethods } from "../types";
 
 export class WorkflowContext<TInitialPayload = unknown> {
   protected readonly executor: AutoExecutor;
@@ -74,7 +74,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     stepName: string,
     stepFunction: AsyncStepFunction<TResult>
   ): Promise<TResult> {
-    return this.executor.addFunctionStep(stepName, stepFunction);
+    return this.executor.addStep<TResult>(new LazyFunctionStep(stepName, stepFunction));
   }
 
   /**
@@ -85,7 +85,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
    * @returns
    */
   public async sleep(stepName: string, duration: number): Promise<void> {
-    await this.executor.addSleepStep(stepName, duration);
+    await this.executor.addStep(new LazySleepStep(stepName, duration));
   }
 
   /**
@@ -106,70 +106,19 @@ export class WorkflowContext<TInitialPayload = unknown> {
       // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       time = Math.round(datetime.getTime() / 1000);
     }
-    await this.executor.addSleepUntilStep(stepName, time);
+    await this.executor.addStep(new LazySleepUntilStep(stepName, time));
   }
 
-  /**
-   * Checks request headers and body
-   * - Checks workflow header to determine whether the request is the first request
-   * - Gets the workflow id
-   * - Parses payload
-   * - Returns the steps. If it's the first invocation, steps are empty.
-   *   Otherwise, steps are generated from the request body.
-   *
-   * @param request Request received
-   * @returns Whether the invocation is the initial one, the workflow id and the steps
-   */
-  private static async parseRequest(request: Request): Promise<{
-    isFirstInvocation: boolean;
-    workflowId: string;
-    initialPayload: string;
-    steps: Step[];
-  }> {
-    const versionHeader = request.headers.get(WORKFLOW_PROTOCOL_VERSION_HEADER);
-    const isFirstInvocation = !versionHeader;
-
-    // if it's not the first invocation, verify that the workflow protocal version is correct
-    if (!isFirstInvocation && versionHeader !== WORKFLOW_PROTOCOL_VERSION) {
-      throw new QstashWorkflowError(
-        `Incompatible workflow sdk protocol version. Expected ${WORKFLOW_PROTOCOL_VERSION},` +
-          ` got ${versionHeader} from the request.`
-      );
-    }
-
-    // get workflow id
-    const workflowId = isFirstInvocation
-      ? `wf${nanoid()}`
-      : request.headers.get(WORKFLOW_ID_HEADER) ?? "";
-    if (workflowId.length === 0) {
-      throw new QstashWorkflowError("Couldn't get workflow id from header");
-    }
-
-    // get payload as raw string
-    const payload = await WorkflowParser.getPayload(request);
-
-    if (isFirstInvocation) {
-      // if first invocation, return and `serve` will handle publishing the JSON to QStash
-      return {
-        isFirstInvocation,
-        workflowId,
-        initialPayload: payload ?? "",
-        steps: [],
-      };
-      // if not the first invocation, make sure that body is not empty and parse payload
-    } else {
-      if (!payload) {
-        throw new QstashWorkflowError("Only first call can have an empty body");
-      }
-      const { initialPayload, steps } = WorkflowParser.parsePayload(payload);
-
-      return {
-        isFirstInvocation,
-        workflowId,
-        initialPayload,
-        steps,
-      };
-    }
+  public async call<TResult = unknown, TBody = unknown>(
+    stepName: string,
+    url: string,
+    method: HTTPMethods,
+    body?: TBody,
+    headers?: Record<string, string>
+  ) {
+    return await this.executor.addStep(
+      new LazyCallStep<TResult>(stepName, url, method, body, headers ?? {})
+    );
   }
 
   /**
@@ -178,39 +127,41 @@ export class WorkflowContext<TInitialPayload = unknown> {
    * @param initHeaderValue Whether the invocation should create a new workflow
    * @returns
    */
-  public getHeaders(initHeaderValue: "true" | "false") {
-    return {
+  public getHeaders(initHeaderValue: "true" | "false", step?: Step, contentType?: string) {
+    let baseHeaders: Record<string, string> = {
       [WORKFLOW_INIT_HEADER]: initHeaderValue,
       [WORKFLOW_ID_HEADER]: this.workflowId,
       [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
     };
-  }
 
-  /**
-   * Creates a workflow from a request by parsing the body and checking the
-   * headers.
-   *
-   * @param request request received from the API
-   * @param client QStash client
-   * @param initialPayloadParser function to parse the initial payload
-   * @returns workflow and whether its the first time the workflow is being called
-   */
-  static async createContext<TInitialPayload = unknown>(
-    request: Request,
-    client: Client,
-    initialPayloadParser: InitialPayloadParser<TInitialPayload>
-  ) {
-    const { isFirstInvocation, workflowId, initialPayload, steps } =
-      await WorkflowContext.parseRequest(request);
+    if (step?.callHeaders && step.callMethod) {
+      const forwardedHeaders = Object.fromEntries(
+        Object.entries(step.callHeaders).map(([header, value]) => [
+          `Upstash-Forward-${header}`,
+          value,
+        ])
+      );
+      baseHeaders = {
+        ...baseHeaders,
+        "Upstash-Callback": this.url,
+        "Upstash-Callback-Workflow-Id": this.workflowId,
+        "Upstash-Callback-Workflow-CallType": "fromCallback",
+        "Upstash-Callback-Workflow-Init": "false",
 
-    const workflowContext = new WorkflowContext<TInitialPayload>({
-      client,
-      workflowId,
-      initialPayload: initialPayloadParser(initialPayload),
-      steps,
-      url: request.url,
-    });
+        "Upstash-Callback-Forward-Upstash-Workflow-Callback": "true",
+        "Upstash-Callback-Forward-Upstash-Workflow-StepId": step.stepId.toString(),
+        "Upstash-Callback-Forward-Upstash-Workflow-StepName": step.stepName,
+        "Upstash-Callback-Forward-Upstash-Workflow-StepType": step.stepType,
+        "Upstash-Callback-Forward-Upstash-Workflow-Concurrent": step.concurrent.toString(),
+        "Upstash-Callback-Forward-Upstash-Workflow-ContentType":
+          contentType ?? DEFAULT_CONTENT_TYPE,
+        // "Upstash-Workflow-Id": this.workflowId,
+        "Upstash-Workflow-CallType": "toCallback",
+        // upstashHeader.Set(InitHeader, "false")
+        ...forwardedHeaders,
+      };
+    }
 
-    return { workflowContext, isFirstInvocation };
+    return baseHeaders;
   }
 }

--- a/src/client/workflow/context.ts
+++ b/src/client/workflow/context.ts
@@ -127,20 +127,23 @@ export class WorkflowContext<TInitialPayload = unknown> {
    * @param initHeaderValue Whether the invocation should create a new workflow
    * @returns
    */
-  public getHeaders(initHeaderValue: "true" | "false", step?: Step, contentType?: string) {
+  public getHeaders(initHeaderValue: "true" | "false", step?: Step) {
     let baseHeaders: Record<string, string> = {
       [WORKFLOW_INIT_HEADER]: initHeaderValue,
       [WORKFLOW_ID_HEADER]: this.workflowId,
       [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
     };
 
-    if (step?.callHeaders && step.callMethod) {
+    if (step?.callUrl) {
       const forwardedHeaders = Object.fromEntries(
         Object.entries(step.callHeaders).map(([header, value]) => [
           `Upstash-Forward-${header}`,
           value,
         ])
       );
+
+      const contentType = step.callHeaders["Content-Type"] as string | undefined;
+
       baseHeaders = {
         ...baseHeaders,
         "Upstash-Callback": this.url,

--- a/src/client/workflow/serve.ts
+++ b/src/client/workflow/serve.ts
@@ -4,7 +4,7 @@ import { WorkflowContext } from "./context";
 import type { WorkflowServeOptions, WorkflowServeParameters } from "./types";
 import { parseRequest, validateRequest } from "./workflow-parser";
 import {
-  handleCallReturn,
+  handleThirdPartyCallResult,
   triggerFirstInvocation,
   triggerRouteFunction,
   triggerWorkflowDelete,
@@ -76,7 +76,7 @@ export const serve = <
    * @returns A promise that resolves to a response.
    */
   return async (request: TRequest) => {
-    const callReturnCheck = await handleCallReturn(request, client);
+    const callReturnCheck = await handleThirdPartyCallResult(request, client);
 
     if (callReturnCheck.isErr()) {
       throw callReturnCheck.error;

--- a/src/client/workflow/serve.ts
+++ b/src/client/workflow/serve.ts
@@ -2,7 +2,9 @@
 import { Client } from "../client";
 import { WorkflowContext } from "./context";
 import type { WorkflowServeOptions, WorkflowServeParameters } from "./types";
+import { parseRequest, validateRequest } from "./workflow-parser";
 import {
+  handleCallReturn,
   triggerFirstInvocation,
   triggerRouteFunction,
   triggerWorkflowDelete,
@@ -74,21 +76,38 @@ export const serve = <
    * @returns A promise that resolves to a response.
    */
   return async (request: TRequest) => {
-    const { workflowContext, isFirstInvocation } =
-      await WorkflowContext.createContext<TInitialPayload>(request, client, initialPayloadParser);
+    const callReturnCheck = await handleCallReturn(request, client);
 
-    const result = isFirstInvocation
-      ? await triggerFirstInvocation(workflowContext)
-      : await triggerRouteFunction({
-          onStep: async () => routeFunction(workflowContext),
-          onCleanup: async () => triggerWorkflowDelete(workflowContext),
-        });
+    if (callReturnCheck.isErr()) {
+      throw callReturnCheck.error;
+    } else if (callReturnCheck.value === "continue-workflow") {
+      const { isFirstInvocation, workflowId } = validateRequest(request);
+      const { initialPayload, steps } = await parseRequest(request, isFirstInvocation);
 
-    if (result.isErr()) {
-      throw result.error;
+      const workflowContext = new WorkflowContext<TInitialPayload>({
+        client,
+        workflowId,
+        initialPayload: initialPayloadParser(initialPayload),
+        steps,
+        url: request.url,
+      });
+
+      const result = isFirstInvocation
+        ? await triggerFirstInvocation(workflowContext)
+        : await triggerRouteFunction({
+            onStep: async () => routeFunction(workflowContext),
+            onCleanup: async () => triggerWorkflowDelete(workflowContext),
+          });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      // Returns a Response with `workflowId` at the end of each step.
+      return onStepFinish(workflowContext.workflowId);
     }
 
-    // Returns a Response with `workflowId` at the end of each step.
-    return onStepFinish(workflowContext.workflowId);
+    // response to QStash in call cases
+    return onStepFinish("no-workflow-id");
   };
 };

--- a/src/client/workflow/steps.ts
+++ b/src/client/workflow/steps.ts
@@ -1,3 +1,4 @@
+import type { HTTPMethods } from "../types";
 import type { AsyncStepFunction, Step, StepType } from "./types";
 
 /**
@@ -145,6 +146,54 @@ export class LazySleepUntilStep extends BaseLazyStep {
       sleepUntil: singleStep ? this.sleepUntil : undefined,
       concurrent: 1,
       targetStep: 0,
+    });
+  }
+}
+
+export class LazyCallStep<TResult = unknown, TBody = unknown> extends BaseLazyStep<TResult> {
+  private readonly url: string;
+  private readonly method: HTTPMethods;
+  private readonly body: TBody;
+  private readonly headers: Record<string, string>;
+  stepType: StepType = "Call";
+
+  constructor(
+    stepName: string,
+    url: string,
+    method: HTTPMethods,
+    body: TBody,
+    headers: Record<string, string>
+  ) {
+    super(stepName);
+    this.url = url;
+    this.method = method;
+    this.body = body;
+    this.headers = headers;
+  }
+
+  public getPlanStep(concurrent: number, targetStep: number): Step<undefined> {
+    {
+      return {
+        stepId: 0,
+        stepName: this.stepName,
+        stepType: this.stepType,
+        concurrent,
+        targetStep,
+      };
+    }
+  }
+
+  public async getResultStep(stepId: number): Promise<Step<TResult>> {
+    return await Promise.resolve({
+      stepId,
+      stepName: this.stepName,
+      stepType: this.stepType,
+      concurrent: 1,
+      targetStep: 0,
+      callUrl: this.url,
+      callMethod: this.method,
+      callBody: this.body,
+      callHeaders: this.headers,
     });
   }
 }

--- a/src/client/workflow/types.ts
+++ b/src/client/workflow/types.ts
@@ -1,9 +1,11 @@
 import type { Client } from "../client";
+import type { HTTPMethods } from "../types";
 import type { WorkflowContext } from "./context";
 
-export type StepType = "Initial" | "Run" | "SleepFor" | "SleepUntil";
+export const StepTypes = ["Initial", "Run", "SleepFor", "SleepUntil", "Call"] as const;
+export type StepType = (typeof StepTypes)[number];
 
-export type Step<TResult = unknown> = {
+export type Step<TResult = unknown, TBody = unknown> = {
   stepId: number;
   stepName: string;
   stepType: StepType;
@@ -12,6 +14,10 @@ export type Step<TResult = unknown> = {
   sleepUntil?: number;
   concurrent: number;
   targetStep: number;
+  callUrl?: string;
+  callMethod?: HTTPMethods;
+  callBody?: TBody;
+  callHeaders?: Record<string, string>;
 };
 
 export type StepInfo<TResult> = {

--- a/src/client/workflow/types.ts
+++ b/src/client/workflow/types.ts
@@ -5,34 +5,64 @@ import type { WorkflowContext } from "./context";
 export const StepTypes = ["Initial", "Run", "SleepFor", "SleepUntil", "Call"] as const;
 export type StepType = (typeof StepTypes)[number];
 
+type ThirdPartyCallFields<TBody = unknown> = {
+  /**
+   * Third party call URL. Set when context.call is used.
+   */
+  callUrl: string;
+  /**
+   * Third party call method. Set when context.call is used.
+   */
+  callMethod: HTTPMethods;
+  /**
+   * Third party call body. Set when context.call is used.
+   */
+  callBody: TBody;
+  /**
+   * Third party call headers. Set when context.call is used.
+   */
+  callHeaders: Record<string, string>;
+};
+
 export type Step<TResult = unknown, TBody = unknown> = {
+  /**
+   * index of the step
+   */
   stepId: number;
+  /**
+   * name of the step
+   */
   stepName: string;
+  /**
+   * type of the step (Initial/Run/SleepFor/SleepUntil/Call)
+   */
   stepType: StepType;
+  /**
+   * step result. Set if context.run or context.call are used.
+   */
   out?: TResult;
+  /**
+   * sleep duration in seconds. Set when context.sleep is used.
+   */
   sleepFor?: number;
+  /**
+   * unix timestamp (in seconds) to wait until. Set when context.sleepUntil is used.
+   */
   sleepUntil?: number;
+  /**
+   * number of steps running concurrently if the step is in a parallel run.
+   * Set to 1 if step is not parallel.
+   */
   concurrent: number;
+  /**
+   * target step of a plan step. In other words, the step to assign the
+   * result of a plan step.
+   *
+   * Set to 0 if the step is not a plan step (of a parallel run). Otherwise,
+   * set to the target step.
+   */
   targetStep: number;
-  callUrl?: string;
-  callMethod?: HTTPMethods;
-  callBody?: TBody;
-  callHeaders?: Record<string, string>;
-};
-
-export type StepInfo<TResult> = {
-  stepName: string;
-  stepFunction: AsyncStepFunction<TResult>;
-};
-
-/**
- * Context received from Qstash
- */
-export type ContextPayload<TResult> = {
-  steps: Step<TResult>[];
-  concurrentStep: number;
-  targetStep: number;
-};
+} & (ThirdPartyCallFields<TBody> | { [P in keyof ThirdPartyCallFields]?: never });
 
 export type SyncStepFunction<TResult> = () => TResult;
 export type AsyncStepFunction<TResult> = () => Promise<TResult>;

--- a/src/client/workflow/workflow-parser.ts
+++ b/src/client/workflow/workflow-parser.ts
@@ -1,4 +1,11 @@
+import { QstashWorkflowError } from "../error";
+import {
+  WORKFLOW_ID_HEADER,
+  WORKFLOW_PROTOCOL_VERSION,
+  WORKFLOW_PROTOCOL_VERSION_HEADER,
+} from "./constants";
 import type { Step } from "./types";
+import { nanoid } from "nanoid";
 
 /**
  * Gets the request body. If that fails, returns undefined
@@ -6,7 +13,7 @@ import type { Step } from "./types";
  * @param request request received in the workflow api
  * @returns request body
  */
-export const getPayload = async (request: Request) => {
+const getPayload = async (request: Request) => {
   try {
     return await request.text();
   } catch {
@@ -37,15 +44,18 @@ const decodeBase64 = (encodedString: string) => {
  * @param rawPayload body of the request as a string as explained above
  * @returns intiial payload and list of steps
  */
-export const parsePayload = (rawPayload: string) => {
+const parsePayload = (rawPayload: string) => {
   const [encodedInitialPayload, ...encodedSteps] = JSON.parse(rawPayload) as {
     messageId: string;
     body: string;
+    callType: "step" | "toCallback" | "fromCallback";
   }[];
 
+  const stepsToDecode = encodedSteps.filter((step) => step.callType === "step");
+
   const initialPayload = decodeBase64(encodedInitialPayload.body);
-  const steps = encodedSteps.map((rawStep) => {
-    return JSON.parse(JSON.parse(decodeBase64(rawStep.body)) as string) as Step;
+  const steps = stepsToDecode.map((rawStep) => {
+    return JSON.parse(decodeBase64(rawStep.body)) as Step;
   });
   const initialStep: Step = {
     stepId: 0,
@@ -59,4 +69,83 @@ export const parsePayload = (rawPayload: string) => {
     initialPayload,
     steps: [initialStep, ...steps],
   };
+};
+
+/**
+ * Validates the incoming request checking the workflow protocol
+ * version and whether it is the first invocation.
+ *
+ * Raises `QstashWorkflowError` if:
+ * - it's not the first invocation and expected protocol version doesn't match
+ *   the request.
+ * - it's not the first invocation but there is no workflow id in the headers.
+ *
+ * @param request request received
+ * @returns whether it's the first invocation and the workflow id
+ */
+export const validateRequest = (
+  request: Request
+): { isFirstInvocation: boolean; workflowId: string } => {
+  const versionHeader = request.headers.get(WORKFLOW_PROTOCOL_VERSION_HEADER);
+  const isFirstInvocation = !versionHeader;
+
+  // if it's not the first invocation, verify that the workflow protocal version is correct
+  if (!isFirstInvocation && versionHeader !== WORKFLOW_PROTOCOL_VERSION) {
+    throw new QstashWorkflowError(
+      `Incompatible workflow sdk protocol version. Expected ${WORKFLOW_PROTOCOL_VERSION},` +
+        ` got ${versionHeader} from the request.`
+    );
+  }
+
+  // get workflow id
+  const workflowId = isFirstInvocation
+    ? `wf${nanoid()}`
+    : request.headers.get(WORKFLOW_ID_HEADER) ?? "";
+  if (workflowId.length === 0) {
+    throw new QstashWorkflowError("Couldn't get workflow id from header");
+  }
+
+  return {
+    isFirstInvocation,
+    workflowId,
+  };
+};
+
+/**
+ * Checks request headers and body
+ * - Reads the request body as raw text
+ * - Returns the steps. If it's the first invocation, steps are empty.
+ *   Otherwise, steps are generated from the request body.
+ *
+ * @param request Request received
+ * @returns raw intial payload and the steps
+ */
+export const parseRequest = async (
+  request: Request,
+  isFirstInvocation: boolean
+): Promise<{
+  initialPayload: string;
+  steps: Step[];
+}> => {
+  // get payload as raw string
+  const payload = await getPayload(request);
+
+  if (isFirstInvocation) {
+    // if first invocation, return and `serve` will handle publishing the JSON to QStash
+    return {
+      initialPayload: payload ?? "",
+      steps: [],
+    };
+    // if not the first invocation, make sure that body is not empty and parse payload
+  } else {
+    if (!payload) {
+      throw new QstashWorkflowError("Only first call can have an empty body");
+    }
+    const { initialPayload, steps } = parsePayload(payload);
+
+    return {
+      initialPayload,
+      steps,
+    };
+  }
 };

--- a/src/client/workflow/workflow-requests.test.ts
+++ b/src/client/workflow/workflow-requests.test.ts
@@ -1,0 +1,414 @@
+import { describe, expect, test } from "bun:test";
+import { serve } from "bun";
+import { nanoid } from "nanoid";
+
+import {
+  getHeaders,
+  handleThirdPartyCallResult,
+  recreateUserHeaders,
+  triggerRouteFunction,
+  triggerWorkflowDelete,
+} from "./workflow-requests";
+import { QstashWorkflowAbort } from "../error";
+import { WorkflowContext } from "./context";
+import { Client } from "../client";
+import type { Step, StepType } from "./types";
+import {
+  WORKFLOW_ID_HEADER,
+  WORKFLOW_INIT_HEADER,
+  WORKFLOW_PROTOCOL_VERSION,
+  WORKFLOW_PROTOCOL_VERSION_HEADER,
+} from "./constants";
+
+const MOCK_SERVER_PORT = 8080;
+const MOCK_SERVER_URL = `http://localhost:${MOCK_SERVER_PORT}`;
+const WORKFLOW_ENDPOINT = "https://www.my-website.com/api";
+/**
+ * Create a HTTP client to mock QStash. We pass the URL of the mock server
+ * as baseUrl and verify that the request is as we expect.
+ *
+ * @param execute function which will call QStash
+ * @param responseBody response returned from QStash
+ * @param responseStatus response status returned from QStash
+ * @param requestFields fields of the request sent to QStash as a result of running
+ *    `await execute()`.
+ */
+const mockQstashServer = async ({
+  execute,
+  responseBody,
+  responseStatus,
+  requestFields,
+}: {
+  execute: () => Promise<unknown>;
+  responseBody: unknown;
+  responseStatus: number;
+  requestFields?: {
+    method: string;
+    url: string;
+    token: string;
+    body?: unknown;
+  };
+}) => {
+  const shouldBeCalled = Boolean(requestFields);
+  let called = false;
+
+  const server = serve({
+    async fetch(request) {
+      called = true;
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const { method, url, token, body } = requestFields!;
+      try {
+        expect(request.method).toBe(method);
+        expect(request.url).toBe(url);
+        expect(request.headers.get("authorization")).toBe(`Bearer ${token}`);
+        if (body) {
+          expect(await request.json()).toEqual(body);
+        }
+      } catch (error) {
+        if (error instanceof Error) {
+          return new Response(JSON.stringify(error, Object.getOwnPropertyNames(error)), {
+            status: 400,
+          });
+        }
+      }
+      return new Response(JSON.stringify(responseBody), { status: responseStatus });
+    },
+    port: MOCK_SERVER_PORT,
+  });
+
+  try {
+    await execute();
+    expect(called).toBe(shouldBeCalled);
+  } finally {
+    server.stop(true);
+  }
+};
+
+describe("Workflow Requests", () => {
+  describe("triggerRouteFunction", () => {
+    test("test step finish", async () => {
+      const result = await triggerRouteFunction({
+        onStep: () => {
+          throw new QstashWorkflowAbort("name");
+        },
+        onCleanup: async () => {
+          await Promise.resolve();
+        },
+      });
+      expect(result.isOk()).toBeTrue();
+      // @ts-expect-error value will be set since stepFinish isOk
+      expect(result.value).toBe("step-finished");
+    });
+
+    test("test workflow finish", async () => {
+      const result = await triggerRouteFunction({
+        onStep: async () => {
+          await Promise.resolve();
+        },
+        onCleanup: async () => {
+          await Promise.resolve();
+        },
+      });
+      expect(result.isOk()).toBeTrue();
+      // @ts-expect-error value will be set since stepFinish isOk
+      expect(result.value).toBe("workflow-finished");
+    });
+
+    test("test error in step", async () => {
+      const result = await triggerRouteFunction({
+        onStep: () => {
+          throw new Error("Something went wrong!");
+        },
+        onCleanup: async () => {
+          await Promise.resolve();
+        },
+      });
+      expect(result.isErr()).toBeTrue();
+    });
+
+    test("test error in cleanup", async () => {
+      const result = await triggerRouteFunction({
+        onStep: async () => {
+          await Promise.resolve();
+        },
+        onCleanup: () => {
+          throw new Error("Something went wrong!");
+        },
+      });
+      expect(result.isErr()).toBeTrue();
+    });
+  });
+
+  test("triggerWorkflowDelete", async () => {
+    const workflowId = nanoid();
+    const token = "myToken";
+
+    const context = new WorkflowContext({
+      client: new Client({ baseUrl: MOCK_SERVER_URL, token }),
+      workflowId: workflowId,
+      initialPayload: undefined,
+      steps: [],
+      url: WORKFLOW_ENDPOINT,
+    });
+
+    await mockQstashServer({
+      execute: async () => {
+        await triggerWorkflowDelete(context);
+      },
+      responseBody: "deleted",
+      responseStatus: 200,
+      requestFields: {
+        method: "DELETE",
+        url: `${MOCK_SERVER_URL}/v2/workflows/${workflowId}?cancel=false`,
+        token,
+        body: undefined,
+      },
+    });
+  });
+
+  test("recreateUserHeaders", () => {
+    const headers = new Headers();
+    headers.append("Upstash-Workflow-Other-Header", "value1");
+    headers.append("My-Header", "value2");
+
+    const newHeaders = recreateUserHeaders(headers as Headers);
+
+    // eslint-disable-next-line unicorn/no-null
+    expect(newHeaders.get("Upstash-Workflow-Other-Header")).toBe(null);
+    expect(newHeaders.get("My-Header")).toBe("value2");
+  });
+
+  describe("handleThirdPartyCallResult", () => {
+    test("is-call-return case", async () => {
+      // request parameters
+      const thirdPartyCallResult = "third-party-call-result";
+      const requestPayload = { status: 200, body: btoa(thirdPartyCallResult) };
+      const stepName = "test step";
+      const stepType: StepType = "Run";
+      const workflowId = nanoid();
+
+      // create client
+      const token = "myToken";
+      const client = new Client({ baseUrl: MOCK_SERVER_URL, token });
+
+      // create the request which will be received by the serve method:
+      const request = new Request(WORKFLOW_ENDPOINT, {
+        method: "POST",
+        body: JSON.stringify(requestPayload),
+        headers: new Headers({
+          "Upstash-Workflow-Callback": "true",
+          "Upstash-Workflow-StepId": "3",
+          "Upstash-Workflow-StepName": stepName,
+          "Upstash-Workflow-StepType": stepType,
+          "Upstash-Workflow-Concurrent": "1",
+          "Upstash-Workflow-ContentType": "application/json",
+          [WORKFLOW_ID_HEADER]: workflowId,
+        }),
+      });
+
+      // create mock server and run the code
+      await mockQstashServer({
+        execute: async () => {
+          const result = await handleThirdPartyCallResult(request, client);
+          expect(result.isOk());
+          // @ts-expect-error value will be set since stepFinish isOk
+          expect(result.value).toBe("is-call-return");
+        },
+        responseBody: { messageId: "msgId" },
+        responseStatus: 200,
+        requestFields: {
+          method: "POST",
+          url: `${MOCK_SERVER_URL}/v2/publish/${WORKFLOW_ENDPOINT}`,
+          token,
+          body: {
+            stepId: 3,
+            stepName: stepName,
+            stepType: stepType,
+            out: thirdPartyCallResult,
+            concurrent: 1,
+            targetStep: 0,
+          },
+        },
+      });
+    });
+
+    test("call-will-retry case (no request to QStash)", async () => {
+      // in this test, the SDK receives a request with "Upstash-Workflow-Callback": "true"
+      // but the status is not OK, so we have to do nothing return `call-will-retry`
+
+      // request parameters
+      const thirdPartyCallResult = "third-party-call-result";
+
+      // status set to 404 which should make QStash retry. workflow sdk should do nothing
+      // in this case
+      const requestPayload = { status: 404, body: btoa(thirdPartyCallResult) };
+      const stepName = "test step";
+      const stepType: StepType = "Run";
+      const workflowId = nanoid();
+
+      // create client
+      const token = "myToken";
+      const client = new Client({ baseUrl: MOCK_SERVER_URL, token });
+
+      // create the request which will be received by the serve method:
+      const request = new Request(WORKFLOW_ENDPOINT, {
+        method: "POST",
+        body: JSON.stringify(requestPayload),
+        headers: new Headers({
+          "Upstash-Workflow-Callback": "true",
+          "Upstash-Workflow-StepId": "3",
+          "Upstash-Workflow-StepName": stepName,
+          "Upstash-Workflow-StepType": stepType,
+          "Upstash-Workflow-Concurrent": "1",
+          "Upstash-Workflow-ContentType": "application/json",
+          [WORKFLOW_ID_HEADER]: workflowId,
+        }),
+      });
+
+      // create mock server and run the code
+      await mockQstashServer({
+        execute: async () => {
+          const result = await handleThirdPartyCallResult(request, client);
+          expect(result.isOk());
+          // @ts-expect-error value will be set since stepFinish isOk
+          expect(result.value).toBe("call-will-retry");
+        },
+        responseBody: { messageId: "msgId" },
+        responseStatus: 200,
+        // we pass requestFields: undefined to indicate that QStash shouldn't be called
+        requestFields: undefined,
+      });
+    });
+
+    test("continue-workflow case (no request to QStash)", async () => {
+      // payload is a list of steps
+      const initialPayload = "my-payload";
+      const requestPayload: Step[] = [
+        {
+          stepId: 1,
+          stepName: "step name",
+          stepType: "Run",
+          concurrent: 1,
+          targetStep: 0,
+        },
+      ];
+      const workflowId = nanoid();
+
+      // create client
+      const token = "myToken";
+      const client = new Client({ baseUrl: MOCK_SERVER_URL, token });
+
+      // create the request which will be received by the serve method:
+      const initialRequest = new Request(WORKFLOW_ENDPOINT, {
+        method: "POST",
+        body: initialPayload,
+        headers: new Headers({}),
+      });
+
+      const workflowRequest = new Request(WORKFLOW_ENDPOINT, {
+        method: "POST",
+        body: JSON.stringify([initialPayload, requestPayload]),
+        headers: new Headers({
+          [WORKFLOW_INIT_HEADER]: "false",
+          [WORKFLOW_ID_HEADER]: workflowId,
+          [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
+        }),
+      });
+
+      // create mock server and run the code
+      await mockQstashServer({
+        execute: async () => {
+          // first call
+          const initialResult = await handleThirdPartyCallResult(initialRequest, client);
+          expect(initialResult.isOk());
+          // @ts-expect-error value will be set since stepFinish isOk
+          expect(initialResult.value).toBe("continue-workflow");
+
+          // second call
+          const result = await handleThirdPartyCallResult(workflowRequest, client);
+          expect(result.isOk());
+          // @ts-expect-error value will be set since stepFinish isOk
+          expect(result.value).toBe("continue-workflow");
+        },
+        responseBody: { messageId: "msgId" },
+        responseStatus: 200,
+        // we pass requestFields: undefined to indicate that QStash shouldn't be called
+        requestFields: undefined,
+      });
+    });
+  });
+
+  describe("getHeaders", () => {
+    const workflowId = nanoid();
+    test("no step passed", () => {
+      const headers = getHeaders("true", workflowId, WORKFLOW_ENDPOINT);
+      expect(headers).toEqual({
+        [WORKFLOW_INIT_HEADER]: "true",
+        [WORKFLOW_ID_HEADER]: workflowId,
+        [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
+      });
+    });
+
+    test("result step passed", () => {
+      const stepId = 3;
+      const stepName = "some step";
+      const stepType: StepType = "Run";
+
+      const headers = getHeaders("false", workflowId, WORKFLOW_ENDPOINT, {
+        stepId,
+        stepName,
+        stepType: stepType,
+        concurrent: 1,
+        targetStep: 0,
+      });
+      expect(headers).toEqual({
+        [WORKFLOW_INIT_HEADER]: "false",
+        [WORKFLOW_ID_HEADER]: workflowId,
+        [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
+      });
+    });
+
+    test("call step passed", () => {
+      const stepId = 3;
+      const stepName = "some step";
+      const stepType: StepType = "Call";
+      const callUrl = "https://www.some-call-endpoint.com/api";
+      const callMethod = "GET";
+      const callHeaders = {
+        "my-custom-header": "my-custom-header-value",
+      };
+      const callBody = undefined;
+
+      const headers = getHeaders("false", workflowId, WORKFLOW_ENDPOINT, {
+        stepId,
+        stepName,
+        stepType: stepType,
+        concurrent: 1,
+        targetStep: 0,
+        callUrl,
+        callMethod,
+        callHeaders,
+        callBody,
+      });
+      expect(headers).toEqual({
+        [WORKFLOW_INIT_HEADER]: "false",
+        [WORKFLOW_ID_HEADER]: workflowId,
+        [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
+
+        "Upstash-Callback": WORKFLOW_ENDPOINT,
+        "Upstash-Callback-Forward-Upstash-Workflow-Callback": "true",
+        "Upstash-Callback-Forward-Upstash-Workflow-Concurrent": "1",
+        "Upstash-Callback-Forward-Upstash-Workflow-ContentType": "application/json",
+        "Upstash-Callback-Forward-Upstash-Workflow-StepId": stepId.toString(),
+        "Upstash-Callback-Forward-Upstash-Workflow-StepName": stepName,
+        "Upstash-Callback-Forward-Upstash-Workflow-StepType": "Call",
+        "Upstash-Callback-Workflow-CallType": "fromCallback",
+        "Upstash-Callback-Workflow-Id": workflowId,
+        "Upstash-Callback-Workflow-Init": "false",
+        "Upstash-Forward-my-custom-header": "my-custom-header-value",
+        "Upstash-Workflow-CallType": "toCallback",
+      });
+    });
+  });
+});

--- a/src/client/workflow/workflow-requests.ts
+++ b/src/client/workflow/workflow-requests.ts
@@ -80,11 +80,20 @@ export const recreateUserHeaders = (headers: Headers): Headers => {
  *
  * Otherwise, does nothing.
  *
+ * ### How third party calls work
+ *
+ * In third party calls, we publish a message to the third party API.
+ * the result is then returned back to the workflow endpoint.
+ *
+ * Whenever the workflow endpoint receives a request, we first check
+ * if the incoming request is a third party call result coming from QStash.
+ * If so, we send back the result to QStash as a result step.
+ *
  * @param request Incoming request
  * @param client qstash client
  * @returns
  */
-export const handleCallReturn = async (
+export const handleThirdPartyCallResult = async (
   request: Request,
   client: Client
 ): Promise<

--- a/src/client/workflow/workflow-requests.ts
+++ b/src/client/workflow/workflow-requests.ts
@@ -67,7 +67,7 @@ export const recreateUserHeaders = (headers: Headers): Headers => {
 
   const pairs = headers.entries() as unknown as [string, string][];
   for (const [header, value] of pairs) {
-    if (!header.startsWith("Upstash-Workflow-")) {
+    if (!header.toLowerCase().startsWith("upstash-workflow-")) {
       filteredHeaders.append(header, value);
     }
   }

--- a/src/client/workflow/workflow-requests.ts
+++ b/src/client/workflow/workflow-requests.ts
@@ -1,7 +1,16 @@
 import type { Err, Ok } from "neverthrow";
 import { err, fromSafePromise, ok } from "neverthrow";
-import { QstashWorkflowAbort } from "../error";
+import { QstashWorkflowAbort, QstashWorkflowError } from "../error";
 import type { WorkflowContext } from "./context";
+import type { Client } from "../client";
+import {
+  WORKFLOW_ID_HEADER,
+  WORKFLOW_INIT_HEADER,
+  WORKFLOW_PROTOCOL_VERSION,
+  WORKFLOW_PROTOCOL_VERSION_HEADER,
+} from "./constants";
+import type { Step, StepType } from "./types";
+import { StepTypes } from "./types";
 
 export const triggerFirstInvocation = <TInitialPayload>(
   workflowContext: WorkflowContext<TInitialPayload>
@@ -44,4 +53,119 @@ export const triggerWorkflowDelete = async <TInitialPayload>(
     method: "DELETE",
     parseResponseAsJson: false,
   });
+};
+
+/**
+ * Removes headers starting with `Upstash-Workflow-` from the headers
+ *
+ * @param headers incoming headers
+ * @returns headers with `Upstash-Workflow-` headers removed
+ */
+export const recreateUserHeaders = (headers: Headers): Headers => {
+  const filteredHeaders = new Headers();
+
+  const pairs = headers.entries() as unknown as [string, string][];
+  for (const [header, value] of pairs) {
+    if (!header.startsWith("Upstash-Workflow-")) {
+      filteredHeaders.append(header, value);
+    }
+  }
+
+  return filteredHeaders as Headers;
+};
+
+/**
+ * Checks if the request is from a third party call result. If so,
+ * calls qstash to add the result to the ongoing workflow.
+ *
+ * Otherwise, does nothing.
+ *
+ * @param request Incoming request
+ * @param client qstash client
+ * @returns
+ */
+export const handleCallReturn = async (
+  request: Request,
+  client: Client
+): Promise<
+  Ok<"is-call-return" | "continue-workflow" | "call-will-retry", never> | Err<never, Error>
+> => {
+  try {
+    if (request.headers.get("Upstash-Workflow-Callback")) {
+      const callbackMessage = (await request.json()) as {
+        status: number;
+        body: string;
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+      if (!(callbackMessage.status >= 200 && callbackMessage.status < 300)) {
+        // this callback will be retried by the qstash, we just ignore it
+        return ok("call-will-retry");
+      }
+
+      const workflowId = request.headers.get(WORKFLOW_ID_HEADER);
+      const stepIdString = request.headers.get("Upstash-Workflow-StepId");
+      const stepName = request.headers.get("Upstash-Workflow-StepName");
+      const stepType = request.headers.get("Upstash-Workflow-StepType") as StepType;
+      const concurrentString = request.headers.get("Upstash-Workflow-Concurrent");
+      const contentType = request.headers.get("Upstash-Workflow-ContentType");
+
+      if (
+        !(
+          workflowId &&
+          stepIdString &&
+          stepName &&
+          StepTypes.includes(stepType) &&
+          concurrentString &&
+          contentType
+        )
+      ) {
+        throw new Error(
+          `Missing info in callback message source header: ${[
+            workflowId,
+            stepIdString,
+            stepName,
+            stepType,
+            concurrentString,
+            contentType,
+          ]}`
+        );
+      }
+
+      request.headers.append("Content-Type", contentType);
+      request.headers.append(WORKFLOW_INIT_HEADER, "false");
+      request.headers.append(
+        `Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`,
+        WORKFLOW_PROTOCOL_VERSION
+      );
+      const userHeaders = recreateUserHeaders(request.headers as Headers);
+
+      const callResultStep: Step = {
+        stepId: Number(stepIdString),
+        stepName,
+        stepType,
+        out: Buffer.from(callbackMessage.body, "base64").toString(),
+        concurrent: Number(concurrentString),
+        targetStep: 0,
+      };
+
+      await client.publishJSON({
+        headers: userHeaders,
+        method: "POST",
+        body: callResultStep,
+        url: request.url,
+      });
+
+      return ok("is-call-return");
+    } else {
+      return ok("continue-workflow");
+    }
+  } catch (error) {
+    const isCallReturn = request.headers.get("Upstash-Workflow-Callback");
+    return err(
+      new QstashWorkflowError(
+        `Error when handling call return (isCallReturn=${isCallReturn}): ${error}`
+      )
+    );
+  }
 };


### PR DESCRIPTION
additionally, this change includes:
- HTTPMethods type
- splitting the WorkflowContext.parseRequest method into two methods in workflow-parser.ts: validateRequest and parseRequest
- adding handleCallReturn method to workflow-requests.ts file to handle third party call result requests
- adding LazyCallStep to handle third party calls
- removing WorkflowContext.createContext and doing the same work in serve.ts

### Change in the serve method

As a result of the changes above, serve method changed from:
```ts
  return async (request: TRequest) => {
    const { workflowContext, isFirstInvocation } =
      await WorkflowContext.createContext<TInitialPayload>(request, client, initialPayloadParser);

    const result = isFirstInvocation
      ? await triggerFirstInvocation(workflowContext)
      : await triggerRouteFunction({
          onStep: async () => routeFunction(workflowContext),
          onCleanup: async () => triggerWorkflowDelete(workflowContext),
        });

    if (result.isErr()) {
      throw result.error;
    }

    // Returns a Response with `workflowId` at the end of each step.
    return onStepFinish(workflowContext.workflowId);
  };
```
 to:
```ts
  return async (request: TRequest) => {
    const callReturnCheck = await handleCallReturn(request, client);

    if (callReturnCheck.isErr()) {
      throw callReturnCheck.error;
    } else if (callReturnCheck.value === "continue-workflow") {
      const { isFirstInvocation, workflowId } = validateRequest(request);
      const { initialPayload, steps } = await parseRequest(request, isFirstInvocation);

      const workflowContext = new WorkflowContext<TInitialPayload>({
        client,
        workflowId,
        initialPayload: initialPayloadParser(initialPayload),
        steps,
        url: request.url,
      });

      const result = isFirstInvocation
        ? await triggerFirstInvocation(workflowContext)
        : await triggerRouteFunction({
            onStep: async () => routeFunction(workflowContext),
            onCleanup: async () => triggerWorkflowDelete(workflowContext),
          });

      if (result.isErr()) {
        throw result.error;
      }

      // Returns a Response with `workflowId` at the end of each step.
      return onStepFinish(workflowContext.workflowId);
    }

    // response to QStash in call cases
    return onStepFinish("no-workflow-id");
  };
```
I think the new version is clearer in terms of which method does what. In the older version, logic was hidden behind `createWorkflow`.