### PR TITLE
feat: prevent calling llm witout callback

### DIFF
--- a/src/client/llm/chat.test.ts
+++ b/src/client/llm/chat.test.ts
@@ -276,6 +276,24 @@ describe("Test Qstash chat with third party LLMs", () => {
     expect(result.messageId).toBeTruthy();
   });
 
+  test("should publish with llm api", () => {
+    //@ts-expect-error We intentionally omit the callback to ensure the function fails as expected
+    const resultPromise = client.publishJSON({
+      api: { name: "llm", provider: openai({ token: process.env.OPENAI_API_KEY! }) },
+      body: {
+        model: "gpt-3.5-turbo",
+        messages: [
+          {
+            role: "user",
+            content: "Where is the capital of Turkey?",
+          },
+        ],
+      },
+    });
+
+    expect(resultPromise).rejects.toThrow("Callback cannot be undefined when using LLM");
+  });
+
   test("should batch with llm api", async () => {
     const result = await client.batchJSON([
       {

--- a/src/client/llm/utils.ts
+++ b/src/client/llm/utils.ts
@@ -33,3 +33,16 @@ export function appendLLMOptionsIfNeeded<
     headers.set("Authorization", `Bearer ${provider.token}`);
   }
 }
+
+/**
+ * Ensures that a callback is present in the request when using the LLM API.
+ *
+ * @template TBody - The type of the request body.
+ * @param {PublishRequest<TBody>} request - The request object to be validated.
+ * @throws {TypeError} Throws an error if the request is for the LLM API and the callback is missing.
+ */
+export function ensureCallbackPresent<TBody = unknown>(request: PublishRequest<TBody>) {
+  if (request.api?.name === "llm" && !request.callback) {
+    throw new TypeError("Callback cannot be undefined when using LLM");
+  }
+}

--- a/src/client/queue.ts
+++ b/src/client/queue.ts
@@ -1,6 +1,6 @@
 import type { PublishRequest, PublishResponse } from "./client";
 import type { Requester } from "./http";
-import { appendLLMOptionsIfNeeded } from "./llm/utils";
+import { appendLLMOptionsIfNeeded, ensureCallbackPresent } from "./llm/utils";
 import { getRequestPath, prefixHeaders, processHeaders } from "./utils";
 
 export type QueueResponse = {
@@ -135,7 +135,9 @@ export class Queue {
     const headers = prefixHeaders(new Headers(request.headers));
     headers.set("Content-Type", "application/json");
 
-    //If needed, this allows users to directly pass their requests to any open-ai compatible 3rd party llm directly from sdk.
+    // Using LLMs without callbacks is meaningless, that's why we check before going further.
+    ensureCallbackPresent<TBody>(request);
+    // If needed, this allows users to directly pass their requests to any open-ai compatible 3rd party llm directly from sdk.
     appendLLMOptionsIfNeeded<TBody, TRequest>(request, headers);
 
     const response = await this.enqueue({


### PR DESCRIPTION
This PR ensures that all LLM calls must have a callback property.