### PR TITLE
Workflow: Add headers field to `context`

### DIFF
--- a/examples/workflow/nextjs/app/auth/route.ts
+++ b/examples/workflow/nextjs/app/auth/route.ts
@@ -1,0 +1,22 @@
+
+import { serve } from "@upstash/qstash/workflow/nextjs";
+
+export const POST = serve<string>({
+  routeFunction: async context => {
+    
+    if (context.headers.get("authentication") !== "Bearer secretPassword" ) {
+      console.error("Authentication failed.");
+      return
+    }
+    const input = context.requestPayload
+
+    const result1 = await context.run("step1", async () => {
+      return "output 1"
+    });
+
+    const result2 = await context.run("step2", async () => {
+      return "output 2"
+    })
+  }
+})
+  

--- a/examples/workflow/nextjs/app/auth/trigger.sh
+++ b/examples/workflow/nextjs/app/auth/trigger.sh
@@ -1,0 +1,4 @@
+curl 'http://localhost:3000/auth' \
+  -X POST \
+  --data-raw '{"date":123,"email":"my@mail.com","amount":10}' \
+  --header "Authentication: Bearer secretPassword"

--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -257,6 +257,13 @@ export class AutoExecutor {
 
     await this.context.client.batchJSON(
       steps.map((singleStep) => {
+        const headers = getHeaders(
+          "false",
+          this.context.workflowId,
+          this.context.url,
+          this.context.headers,
+          singleStep
+        );
         return singleStep.callUrl
           ? // if the step is a third party call, we call the third party
             // url (singleStep.callUrl) and pass information about the workflow
@@ -265,7 +272,7 @@ export class AutoExecutor {
             // handleThirdPartyCallResult method sends the result of the third
             // party call to QStash.
             {
-              headers: getHeaders("false", this.context.workflowId, this.context.url, singleStep),
+              headers,
               method: singleStep.callMethod,
               body: singleStep.callBody,
               url: singleStep.callUrl,
@@ -274,7 +281,7 @@ export class AutoExecutor {
             // endpoint (context.url) as URL when calling QStash. QStash
             // calls us back with the updated steps list.
             {
-              headers: getHeaders("false", this.context.workflowId, this.context.url, singleStep),
+              headers,
               method: "POST",
               body: singleStep,
               url: this.context.url,

--- a/src/client/workflow/constants.ts
+++ b/src/client/workflow/constants.ts
@@ -1,5 +1,6 @@
 export const WORKFLOW_ID_HEADER = "Upstash-Workflow-Id";
 export const WORKFLOW_INIT_HEADER = "Upstash-Workflow-Init";
+export const WORKFLOW_URL_HEADER = "Upstash-Workflow-Url";
 
 export const WORKFLOW_PROTOCOL_VERSION = "1";
 export const WORKFLOW_PROTOCOL_VERSION_HEADER = "Upstash-Workflow-Sdk-Version";

--- a/src/client/workflow/context.ts
+++ b/src/client/workflow/context.ts
@@ -12,17 +12,20 @@ export class WorkflowContext<TInitialPayload = unknown> {
   public readonly nonPlanStepCount: number;
   public readonly url: string;
   public readonly requestPayload: TInitialPayload;
+  public readonly headers: Headers;
 
   constructor({
     client,
     workflowId,
     initialPayload,
+    headers,
     steps,
     url,
   }: {
     client: Client;
     workflowId: string;
     initialPayload: TInitialPayload;
+    headers: Headers;
     steps: Step[];
     url: string;
   }) {
@@ -31,6 +34,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     this.steps = steps;
     this.url = url;
     this.requestPayload = initialPayload;
+    this.headers = headers;
     this.nonPlanStepCount = this.steps.filter((step) => !step.targetStep).length;
 
     this.executor = new AutoExecutor(this);

--- a/src/client/workflow/serve.ts
+++ b/src/client/workflow/serve.ts
@@ -41,6 +41,7 @@ const processOptions = <TResponse = Response, TInitialPayload = unknown>(
       ((initialRequest: string) => {
         return (initialRequest ? JSON.parse(initialRequest) : undefined) as TInitialPayload;
       }),
+    url: options?.url ?? "",
   };
 };
 
@@ -63,9 +64,10 @@ export const serve = <
   request: TRequest
 ) => Promise<TResponse>) => {
   // Prepares options with defaults if they are not provided.
-  const { client, onStepFinish, initialPayloadParser } = processOptions<TResponse, TInitialPayload>(
-    options
-  );
+  const { client, onStepFinish, initialPayloadParser, url } = processOptions<
+    TResponse,
+    TInitialPayload
+  >(options);
 
   /**
    * Handles the incoming request, triggering the appropriate workflow steps.
@@ -91,7 +93,7 @@ export const serve = <
         initialPayload: initialPayloadParser(initialPayload),
         headers: recreateUserHeaders(request.headers as Headers),
         steps,
-        url: request.url,
+        url: url || request.url,
       });
 
       const result = isFirstInvocation

--- a/src/client/workflow/serve.ts
+++ b/src/client/workflow/serve.ts
@@ -5,6 +5,7 @@ import type { WorkflowServeOptions, WorkflowServeParameters } from "./types";
 import { parseRequest, validateRequest } from "./workflow-parser";
 import {
   handleThirdPartyCallResult,
+  recreateUserHeaders,
   triggerFirstInvocation,
   triggerRouteFunction,
   triggerWorkflowDelete,
@@ -88,6 +89,7 @@ export const serve = <
         client,
         workflowId,
         initialPayload: initialPayloadParser(initialPayload),
+        headers: recreateUserHeaders(request.headers as Headers),
         steps,
         url: request.url,
       });

--- a/src/client/workflow/types.ts
+++ b/src/client/workflow/types.ts
@@ -113,4 +113,10 @@ export type WorkflowServeOptions<TResponse = Response, TInitialPayload = unknown
    * Function to parse the initial payload passed by the user
    */
   initialPayloadParser?: InitialPayloadParser<TInitialPayload>;
+  /**
+   * Url of the endpoint where the workflow is set up.
+   *
+   * If not set, url will be inferred from the request.
+   */
+  url?: string;
 };

--- a/src/client/workflow/workflow-requests.test.ts
+++ b/src/client/workflow/workflow-requests.test.ts
@@ -18,6 +18,7 @@ import {
   WORKFLOW_INIT_HEADER,
   WORKFLOW_PROTOCOL_VERSION,
   WORKFLOW_PROTOCOL_VERSION_HEADER,
+  WORKFLOW_URL_HEADER,
 } from "./constants";
 
 const MOCK_SERVER_PORT = 8080;
@@ -148,6 +149,7 @@ describe("Workflow Requests", () => {
       client: new Client({ baseUrl: MOCK_SERVER_URL, token }),
       workflowId: workflowId,
       initialPayload: undefined,
+      headers: new Headers({}) as Headers,
       steps: [],
       url: WORKFLOW_ENDPOINT,
     });
@@ -312,6 +314,7 @@ describe("Workflow Requests", () => {
         headers: new Headers({
           [WORKFLOW_INIT_HEADER]: "false",
           [WORKFLOW_ID_HEADER]: workflowId,
+          [WORKFLOW_URL_HEADER]: WORKFLOW_ENDPOINT,
           [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
         }),
       });
@@ -346,6 +349,7 @@ describe("Workflow Requests", () => {
       expect(headers).toEqual({
         [WORKFLOW_INIT_HEADER]: "true",
         [WORKFLOW_ID_HEADER]: workflowId,
+        [WORKFLOW_URL_HEADER]: WORKFLOW_ENDPOINT,
         [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
       });
     });
@@ -355,7 +359,7 @@ describe("Workflow Requests", () => {
       const stepName = "some step";
       const stepType: StepType = "Run";
 
-      const headers = getHeaders("false", workflowId, WORKFLOW_ENDPOINT, {
+      const headers = getHeaders("false", workflowId, WORKFLOW_ENDPOINT, undefined, {
         stepId,
         stepName,
         stepType: stepType,
@@ -365,6 +369,7 @@ describe("Workflow Requests", () => {
       expect(headers).toEqual({
         [WORKFLOW_INIT_HEADER]: "false",
         [WORKFLOW_ID_HEADER]: workflowId,
+        [WORKFLOW_URL_HEADER]: WORKFLOW_ENDPOINT,
         [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
       });
     });
@@ -380,7 +385,7 @@ describe("Workflow Requests", () => {
       };
       const callBody = undefined;
 
-      const headers = getHeaders("false", workflowId, WORKFLOW_ENDPOINT, {
+      const headers = getHeaders("false", workflowId, WORKFLOW_ENDPOINT, undefined, {
         stepId,
         stepName,
         stepType: stepType,
@@ -394,6 +399,7 @@ describe("Workflow Requests", () => {
       expect(headers).toEqual({
         [WORKFLOW_INIT_HEADER]: "false",
         [WORKFLOW_ID_HEADER]: workflowId,
+        [WORKFLOW_URL_HEADER]: WORKFLOW_ENDPOINT,
         [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
 
         "Upstash-Callback": WORKFLOW_ENDPOINT,


### PR DESCRIPTION
addiitonally, with this change we add the `Upstash-Workflow-Url` header and pass the user headers during workflow (they are available in `context.headers`)