### PR TITLE
Workflow: Verbose mode & tests

### DIFF
--- a/examples/solidjs/.env.local.example
+++ b/examples/solidjs/.env.local.example
@@ -1,0 +1,2 @@
+QSTASH_TOKEN="***"
+QSTASH_URL="***"

--- a/examples/workflow/README.md
+++ b/examples/workflow/README.md
@@ -1,0 +1,39 @@
+# Workflow Examples
+
+This directory has example projects for QStash Workflows with different frameworks.
+
+Each project has an interface where you can enter the deployment URL, pick a workflow endpoint, enter a payload and finally call the picked workflow endpoint.
+
+## How to Run
+
+There are three alternatives:
+1. Deploy the app and use the interface to call it
+2. Run the app locally and create a local tunnel with Ngrok so that QStash can call it. Doing this is simplified through the `bootstrap.sh` script.
+3. If you have access to the QStash development server, run both the development server and the example workflow project locally. Unfortunetly, local QStash development server is not public.
+
+### `bootstrap.sh` Script
+
+The `bootstrap.sh` script makes it possible to start an examplew workflow project and create a Ngrok tunnel in one script. To run it, simply choose the framework and the endpoint you would like to choose as default:
+
+```
+bash bootstrap.sh <example-framework> <workflow-endpoint>
+```
+
+Here is an example call:
+
+```
+bash bootstrap.sh nextjs path
+```
+
+You will still be able to use endpoints other than `path`. `path` will simply be what the home page will have as default endpoint.
+
+Here is what the script does in a nutshell:
+- create a Ngrok tunnel from `localhost:3000`
+- Public URL of the tunnel is inferred from Ngrok logs.
+- `context.ts` file in `@upstash/qstash` is updated with the URL from Ngrok.
+- `@upstash/qstash` is built and installed in the picked framework example
+- a web browser is opened with the picked endpoint
+
+To use the app, simply enter the ngrok URL to the `Base URL` field of the form and send a request.
+
+You will be able to see the workflow executing in the console logs. You can also monitor the events in [the QStash tab of Upstash Console](https://console.upstash.com/qstash?tab=events).

--- a/examples/workflow/bootstrap.sh
+++ b/examples/workflow/bootstrap.sh
@@ -7,8 +7,11 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
+# store project argument
+project_arg="$1"
+
 # Store the path argument
-path_arg="$1"
+path_arg="$2"
 
 # Start ngrok and capture the public URL
 ngrok http localhost:3000 --log=stdout > ngrok.log &
@@ -19,10 +22,15 @@ sleep 5  # Allow some time for ngrok to start
 ngrok_url=$(grep -o 'url=https://[a-zA-Z0-9.-]*\.ngrok-free\.app' ngrok.log | cut -d '=' -f 2 | head -n1)
 
 # Append the path argument to the ngrok URL
-full_url="${ngrok_url}/${path_arg}"
+if [ "$project_arg" == "nuxt" ]; then
+    full_url="${ngrok_url}/api/${path_arg}"
+else
+    full_url="${ngrok_url}/${path_arg}"
+fi
 
 # Navigate to the parent directory
 cd ../..
+
 
 # Update the URL in the context.ts file
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -38,15 +46,14 @@ bun install
 bun run build
 
 # Navigate to the examples/workflow directory
-cd examples/workflow
+cd examples/workflow/${project_arg}
 
 # Install the local package
-npm install @upstash/qstash@file:../../dist
+npm install @upstash/qstash@file:../../../dist
 
 final_path=$ngrok_url?function=$path_arg
 echo "Setup complete. Full URL: $final_path"
 echo "ngrok is running. Press Ctrl+C to stop it."
-
 
 
 # Open the URL in Chrome

--- a/examples/workflow/nextjs/README.md
+++ b/examples/workflow/nextjs/README.md
@@ -21,7 +21,7 @@ At this point, if you are using a released `@upstash/qstash` version, you can de
 ```
 cd ../../..
 
-npm install
+bun install
 npm run build
 
 cd examples/workflow/nextjs

--- a/examples/workflow/nextjs/app/page.tsx
+++ b/examples/workflow/nextjs/app/page.tsx
@@ -1,13 +1,20 @@
 "use client"
 
-import { usePathname, useSearchParams } from 'next/navigation';
-import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 export default function Home() {
   const [baseUrl, setBaseUrl] = useState("http://localhost:3000");
   const [requestBody, setRequestBody] = useState('{"date":123,"email":"my@mail.com","amount":10}');
   const [loading, setLoading] = useState(false);
   const searchParams = useSearchParams();
+
+  // Ensure baseUrl doesn't have a trailing slash
+  useEffect(() => {
+    if (baseUrl.endsWith('/')) {
+      setBaseUrl(baseUrl.replace(/\/$/, ''));
+    }
+  }, [baseUrl]);
 
   const search = searchParams.get('function');
   const [route, setRoute] = useState(search ?? "path");
@@ -39,7 +46,7 @@ export default function Home() {
         <h1 className="text-xl font-bold mb-4">Send Request</h1>
 
         <div className="mb-4">
-          <label className="block text-gray-700">Base URL:</label>
+          <label className="block text-gray-700">Base URL (replace with deployment URL):</label>
           <input
             type="text"
             value={baseUrl}

--- a/examples/workflow/nuxt/nuxt.config.ts
+++ b/examples/workflow/nuxt/nuxt.config.ts
@@ -13,4 +13,7 @@ export default defineNuxtConfig({
       autoprefixer: {},
     },
   },
+  devServer: {
+    port: 3000
+  }
 })

--- a/examples/workflow/nuxt/pages/index.vue
+++ b/examples/workflow/nuxt/pages/index.vue
@@ -4,7 +4,7 @@
       <h1 class="text-xl font-bold mb-4">Send Request</h1>
 
       <div class="mb-4">
-        <label class="block text-gray-700">Base URL:</label>
+        <label class="block text-gray-700">Base URL deployment URL:</label>
         <input
           v-model="baseUrl"
           type="text"
@@ -53,6 +53,13 @@ const requestBody = ref('{"date":123,"email":"my@mail.com","amount":10}');
 const loading = ref(false);
 const route = ref('path');
 const routes = ['path', 'sleep', 'sleepWithoutAwait', 'northStarSimple', 'northStar'];
+
+// Ensure baseUrl doesn't have a trailing slash
+watch(baseUrl, (newVal) => {
+  if (newVal.endsWith('/')) {
+    baseUrl.value = newVal.replace(/\/$/, '');
+  }
+});
 
 const handleSend = async () => {
   loading.value = true;

--- a/examples/workflow/solidjs/src/routes/index.tsx
+++ b/examples/workflow/solidjs/src/routes/index.tsx
@@ -1,10 +1,18 @@
-import { createSignal } from 'solid-js';
+import { createSignal, createEffect } from 'solid-js';
 
 const LandingPage = () => {
   const [baseUrl, setBaseUrl] = createSignal("http://localhost:3000");
   const [requestBody, setRequestBody] = createSignal('{"date":123,"email":"my@mail.com","amount":10}');
   const [route, setRoute] = createSignal("path");
   const [loading, setLoading] = createSignal(false);
+
+  // Ensure baseUrl doesn't have a trailing slash
+  createEffect(() => {
+    const url = baseUrl();
+    if (url.endsWith('/')) {
+      setBaseUrl(url.replace(/\/$/, ''));
+    }
+  });
 
   const routes = ['path', 'sleep', 'sleepWithoutAwait', 'northStarSimple', 'northStar'];
 
@@ -33,7 +41,7 @@ const LandingPage = () => {
         <h1 className="text-xl font-bold mb-4">Send Request</h1>
 
         <div className="mb-4">
-          <label className="block text-gray-700">Base URL:</label>
+          <label className="block text-gray-700">Base URL (replace with deployment URL):</label>
           <input
             type="text"
             value={baseUrl()}

--- a/examples/workflow/sveltekit/src/routes/+page.svelte
+++ b/examples/workflow/sveltekit/src/routes/+page.svelte
@@ -3,10 +3,17 @@
   import { page } from '$app/stores';
   import { writable } from 'svelte/store';
 
-  let baseUrl = writable("http://localhost:5173");
+  let baseUrl = writable("http://localhost:3000");
   let requestBody = writable('{"date":123,"email":"my@mail.com","amount":10}');
   let loading = writable(false);
   let route = writable('path');
+
+  // Ensure baseUrl doesn't have a trailing slash
+  baseUrl.subscribe(value => {
+    if (value.endsWith('/')) {
+      baseUrl.set(value.replace(/\/$/, ''));
+    }
+  });
 
   const routes = ['path', 'sleep', 'sleepWithoutAwait', 'northStarSimple', 'northStar'];
 
@@ -35,7 +42,7 @@
     <h1 class="text-xl font-bold mb-4">Send Request</h1>
 
     <div class="mb-4">
-      <label class="block text-gray-700">Base URL:</label>
+      <label class="block text-gray-700">Base URL (replace with deployment URL):</label>
       <input
         type="text"
         bind:value={$baseUrl}

--- a/examples/workflow/sveltekit/vite.config.ts
+++ b/examples/workflow/sveltekit/vite.config.ts
@@ -6,4 +6,7 @@ export default defineConfig({
     resolve: {
         preserveSymlinks: true,
     },
+    server: {
+      port: 3000,
+    },
 });

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -187,7 +187,7 @@ describe("E2E Queue", () => {
         endpoints: [{ url: "https://example.com/", name: "first" }],
       });
 
-      await client.batch([
+      const result = await client.batch([
         {
           urlGroup: urlGroup,
           body: "message",
@@ -198,6 +198,32 @@ describe("E2E Queue", () => {
           queueName,
         },
       ]);
+      expect(Array.isArray(result)).toBeTrue();
+      await client.queue({ queueName }).delete();
+    },
+    { timeout: 35_000 }
+  );
+
+  test(
+    "should return batch result as array when there is a single item",
+    async () => {
+      const queueName = nanoid();
+      const urlGroup = nanoid();
+
+      await client.queue({ queueName }).upsert({ parallelism: 1 });
+      await client.urlGroups.addEndpoints({
+        name: urlGroup,
+        endpoints: [{ url: "https://example.com/", name: "first" }],
+      });
+
+      const result = await client.batch([
+        {
+          urlGroup: urlGroup,
+          body: "message",
+          queueName,
+        },
+      ]);
+      expect(Array.isArray(result)).toBeTrue();
       await client.queue({ queueName }).delete();
     },
     { timeout: 35_000 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -368,8 +368,9 @@ export class Client {
       },
       method: "POST",
     });
+    const arrayResposne = Array.isArray(response) ? response : [response];
 
-    return response;
+    return arrayResposne;
   }
 
   /**

--- a/src/client/workflow/auto-executor.test.ts
+++ b/src/client/workflow/auto-executor.test.ts
@@ -1,0 +1,424 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+import { describe, expect, spyOn, test } from "bun:test";
+import { WorkflowContext } from "./context";
+import { Client } from "../client";
+import { MOCK_QSTASH_SERVER_URL, mockQstashServer, WORKFLOW_ENDPOINT } from "./test-utils";
+import { nanoid } from "nanoid";
+import { AutoExecutor } from "./auto-executor";
+import type { Step } from "./types";
+import { QstashWorkflowAbort } from "../error";
+
+class SpyAutoExecutor extends AutoExecutor {
+  public declare getParallelCallState;
+  public declare runSingle;
+  public declare runParallel;
+}
+
+class SpyWorkflowContext extends WorkflowContext {
+  public declare executor: SpyAutoExecutor;
+}
+
+/**
+ * in these tests, we create a context by passing it
+ * steps manually.
+ *
+ * In each test, we:
+ * - create a context from `initialStep`, `singleStep` and `parallelSteps`
+ * - create spies on runSingle and runParallel of the auto-executor
+ * - create a mock qstash server (the server is provided the expected request body/method/headers)
+ * - run single step or parallel steps in different stages of execution and check the server
+ * - check how the spy was called
+ */
+describe("auto-executor", () => {
+  const initialPayload = { initial: "payload" };
+  const token = nanoid();
+  const workflowId = nanoid();
+
+  const initialStep: Step = {
+    stepId: 0,
+    stepName: "init",
+    stepType: "Initial",
+    out: JSON.stringify(initialPayload),
+    concurrent: 1,
+    targetStep: 0,
+  };
+
+  const singleStep: Step = {
+    stepId: 1,
+    stepName: "attemptCharge",
+    stepType: "Run",
+    out: { input: initialPayload, success: false },
+    concurrent: 1,
+    targetStep: 0,
+  };
+
+  const parallelSteps: Step[] = [
+    {
+      stepId: 0,
+      stepName: "sleep for some time",
+      stepType: "SleepFor",
+      sleepFor: 123,
+      concurrent: 2,
+      targetStep: 1,
+    },
+    {
+      stepId: 0,
+      stepName: "sleep until next day",
+      stepType: "SleepUntil",
+      sleepUntil: 123_123,
+      concurrent: 2,
+      targetStep: 2,
+    },
+    {
+      stepId: 1,
+      stepName: "sleep for some time",
+      stepType: "SleepFor",
+      concurrent: 1,
+      targetStep: 0,
+    },
+    {
+      stepId: 2,
+      stepName: "sleep until next day",
+      stepType: "SleepUntil",
+      concurrent: 1,
+      targetStep: 0,
+    },
+  ];
+
+  const getContext = (steps: Step[]) => {
+    return new SpyWorkflowContext({
+      client: new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token }),
+      workflowId,
+      initialPayload,
+      headers: new Headers({}) as Headers,
+      steps,
+      url: WORKFLOW_ENDPOINT,
+    });
+  };
+
+  describe("single step", () => {
+    test("should send a single step", async () => {
+      const context = getContext([initialStep]);
+
+      const spyRunSingle = spyOn(context.executor, "runSingle");
+      const spyRunParallel = spyOn(context.executor, "runParallel");
+
+      await mockQstashServer({
+        // eslint-disable-next-line @typescript-eslint/require-await
+        execute: async () => {
+          const throws = context.run("attemptCharge", async () => {
+            return await Promise.resolve({ input: context.requestPayload, success: false });
+          });
+          expect(throws).rejects.toThrowError(QstashWorkflowAbort);
+        },
+        responseFields: {
+          status: 200,
+          body: "msgId",
+        },
+        receivesRequest: {
+          method: "POST",
+          url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+          token,
+          body: [
+            {
+              destination: WORKFLOW_ENDPOINT,
+              headers: {
+                "content-type": "application/json",
+                "upstash-forward-upstash-workflow-sdk-version": "1",
+                "upstash-method": "POST",
+                "upstash-workflow-id": workflowId,
+                "upstash-workflow-init": "false",
+                "upstash-workflow-url": WORKFLOW_ENDPOINT,
+              },
+              body: JSON.stringify(singleStep),
+            },
+          ],
+        },
+      });
+
+      expect(spyRunSingle).toHaveBeenCalledTimes(1);
+      const lazyStep = spyRunSingle.mock.calls[0][0];
+      expect(lazyStep.stepName).toBe("attemptCharge");
+      expect(lazyStep.stepType).toBe("Run");
+
+      expect(spyRunParallel).toHaveBeenCalledTimes(0);
+    });
+
+    test("should use single step result from request", async () => {
+      const context = getContext([initialStep, singleStep]);
+
+      const spyRunSingle = spyOn(context.executor, "runSingle");
+      const spyRunParallel = spyOn(context.executor, "runParallel");
+
+      await mockQstashServer({
+        execute: async () => {
+          expect(context.executor.stepCount).toBe(0);
+          expect(context.executor.planStepCount).toBe(0);
+          const result = await context.run("attemptCharge", async () => {
+            return await Promise.resolve({ input: context.requestPayload, success: false });
+          });
+          expect(context.executor.stepCount).toBe(1);
+          expect(context.executor.planStepCount).toBe(0);
+          expect(result).toEqual({ input: context.requestPayload, success: false });
+        },
+        responseFields: {
+          status: 200,
+          body: "msgId",
+        },
+        receivesRequest: false,
+      });
+
+      expect(spyRunSingle).toHaveBeenCalledTimes(1);
+      const lazyStep = spyRunSingle.mock.calls[0][0];
+      expect(lazyStep.stepName).toBe("attemptCharge");
+      expect(lazyStep.stepType).toBe("Run");
+
+      expect(spyRunParallel).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe("parallel steps", () => {
+    test("should send plan steps in first encounter: should send plan steps as batch", async () => {
+      const context = getContext([initialStep]);
+
+      const spyRunSingle = spyOn(context.executor, "runSingle");
+      const spyRunParallel = spyOn(context.executor, "runParallel");
+
+      await mockQstashServer({
+        // eslint-disable-next-line @typescript-eslint/require-await
+        execute: async () => {
+          expect(context.executor.getParallelCallState(2, 1)).toBe("first");
+          const throws = Promise.all([
+            context.sleep("sleep for some time", 123),
+            context.sleepUntil("sleep until next day", 123_123),
+          ]);
+          expect(throws).rejects.toThrowError(QstashWorkflowAbort);
+        },
+        responseFields: {
+          status: 200,
+          body: "msgId",
+        },
+        receivesRequest: {
+          method: "POST",
+          url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+          token,
+          body: [
+            {
+              body: '{"stepId":0,"stepName":"sleep for some time","stepType":"SleepFor","sleepFor":123,"concurrent":2,"targetStep":1}',
+              destination: WORKFLOW_ENDPOINT,
+              headers: {
+                "content-type": "application/json",
+                "upstash-delay": "123s",
+                "upstash-forward-upstash-workflow-sdk-version": "1",
+                "upstash-method": "POST",
+                "upstash-workflow-id": workflowId,
+                "upstash-workflow-init": "false",
+                "upstash-workflow-url": WORKFLOW_ENDPOINT,
+              },
+            },
+            {
+              body: '{"stepId":0,"stepName":"sleep until next day","stepType":"SleepUntil","sleepUntil":123123,"concurrent":2,"targetStep":2}',
+              destination: WORKFLOW_ENDPOINT,
+              headers: {
+                "content-type": "application/json",
+                "upstash-forward-upstash-workflow-sdk-version": "1",
+                "upstash-method": "POST",
+                "upstash-not-before": "123123",
+                "upstash-workflow-id": workflowId,
+                "upstash-workflow-init": "false",
+                "upstash-workflow-url": WORKFLOW_ENDPOINT,
+              },
+            },
+          ],
+        },
+      });
+
+      expect(spyRunSingle).toHaveBeenCalledTimes(0);
+
+      expect(spyRunParallel).toHaveBeenCalledTimes(1);
+      const lazySteps = spyRunParallel.mock.calls[0][0];
+      expect(lazySteps.length).toBe(2);
+      expect(lazySteps[0].stepType).toBe("SleepFor");
+      expect(lazySteps[1].stepType).toBe("SleepUntil");
+      expect(lazySteps[0].stepName).toBe("sleep for some time");
+      expect(lazySteps[1].stepName).toBe("sleep until next day");
+    });
+
+    test("should send plan steps in second encounter: should run the first parallel step", async () => {
+      const context = getContext([initialStep, parallelSteps[0]]);
+
+      const spyRunSingle = spyOn(context.executor, "runSingle");
+      const spyRunParallel = spyOn(context.executor, "runParallel");
+
+      await mockQstashServer({
+        // eslint-disable-next-line @typescript-eslint/require-await
+        execute: async () => {
+          expect(context.executor.getParallelCallState(2, 1)).toBe("partial");
+          const throws = Promise.all([
+            context.sleep("sleep for some time", 123),
+            context.sleepUntil("sleep until next day", 123_123),
+          ]);
+          expect(throws).rejects.toThrowError(QstashWorkflowAbort);
+        },
+        responseFields: {
+          status: 200,
+          body: "msgId",
+        },
+        receivesRequest: {
+          method: "POST",
+          url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+          token,
+          body: [
+            {
+              destination: WORKFLOW_ENDPOINT,
+              headers: {
+                "content-type": "application/json",
+                "upstash-forward-upstash-workflow-sdk-version": "1",
+                "upstash-method": "POST",
+                "upstash-workflow-id": workflowId,
+                "upstash-workflow-init": "false",
+                "upstash-workflow-url": WORKFLOW_ENDPOINT,
+              },
+              body: JSON.stringify(parallelSteps[2]),
+            },
+          ],
+        },
+      });
+
+      expect(spyRunSingle).toHaveBeenCalledTimes(0);
+
+      expect(spyRunParallel).toHaveBeenCalledTimes(1);
+      const lazySteps = spyRunParallel.mock.calls[0][0];
+      expect(lazySteps.length).toBe(2);
+      expect(lazySteps[0].stepType).toBe("SleepFor");
+      expect(lazySteps[1].stepType).toBe("SleepUntil");
+      expect(lazySteps[0].stepName).toBe("sleep for some time");
+      expect(lazySteps[1].stepName).toBe("sleep until next day");
+    });
+
+    test("should send plan steps in third encounter: should run the second parallel step", async () => {
+      const context = getContext([initialStep, ...parallelSteps.slice(0, 2)]);
+
+      const spyRunSingle = spyOn(context.executor, "runSingle");
+      const spyRunParallel = spyOn(context.executor, "runParallel");
+
+      await mockQstashServer({
+        // eslint-disable-next-line @typescript-eslint/require-await
+        execute: async () => {
+          expect(context.executor.getParallelCallState(2, 1)).toBe("partial");
+          const throws = Promise.all([
+            context.sleep("sleep for some time", 123),
+            context.sleepUntil("sleep until next day", 123_123),
+          ]);
+          expect(throws).rejects.toThrowError(QstashWorkflowAbort);
+        },
+        responseFields: {
+          status: 200,
+          body: "msgId",
+        },
+        receivesRequest: {
+          method: "POST",
+          url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+          token,
+          body: [
+            {
+              destination: WORKFLOW_ENDPOINT,
+              headers: {
+                "content-type": "application/json",
+                "upstash-forward-upstash-workflow-sdk-version": "1",
+                "upstash-method": "POST",
+                "upstash-workflow-id": workflowId,
+                "upstash-workflow-init": "false",
+                "upstash-workflow-url": WORKFLOW_ENDPOINT,
+              },
+              body: JSON.stringify(parallelSteps[3]),
+            },
+          ],
+        },
+      });
+
+      expect(spyRunSingle).toHaveBeenCalledTimes(0);
+
+      expect(spyRunParallel).toHaveBeenCalledTimes(1);
+      const lazySteps = spyRunParallel.mock.calls[0][0];
+      expect(lazySteps.length).toBe(2);
+      expect(lazySteps[0].stepType).toBe("SleepFor");
+      expect(lazySteps[1].stepType).toBe("SleepUntil");
+      expect(lazySteps[0].stepName).toBe("sleep for some time");
+      expect(lazySteps[1].stepName).toBe("sleep until next day");
+    });
+
+    test("should send plan steps in fourth encounter: should discard", async () => {
+      const context = getContext([initialStep, ...parallelSteps.slice(0, 3)]);
+
+      const spyRunSingle = spyOn(context.executor, "runSingle");
+      const spyRunParallel = spyOn(context.executor, "runParallel");
+
+      await mockQstashServer({
+        // eslint-disable-next-line @typescript-eslint/require-await
+        execute: async () => {
+          expect(context.executor.getParallelCallState(2, 1)).toBe("discard");
+          const throws = Promise.all([
+            context.sleep("sleep for some time", 123),
+            context.sleepUntil("sleep until next day", 123_123),
+          ]);
+          expect(throws).rejects.toThrowError(QstashWorkflowAbort);
+        },
+        responseFields: {
+          status: 200,
+          body: "msgId",
+        },
+        receivesRequest: false,
+      });
+
+      expect(spyRunSingle).toHaveBeenCalledTimes(0);
+
+      expect(spyRunParallel).toHaveBeenCalledTimes(1);
+      const lazySteps = spyRunParallel.mock.calls[0][0];
+      expect(lazySteps.length).toBe(2);
+      expect(lazySteps[0].stepType).toBe("SleepFor");
+      expect(lazySteps[1].stepType).toBe("SleepUntil");
+      expect(lazySteps[0].stepName).toBe("sleep for some time");
+      expect(lazySteps[1].stepName).toBe("sleep until next day");
+    });
+
+    test("should send plan steps in fifth and final encounter: should return the result", async () => {
+      const context = getContext([initialStep, ...parallelSteps]);
+
+      const spyRunSingle = spyOn(context.executor, "runSingle");
+      const spyRunParallel = spyOn(context.executor, "runParallel");
+
+      await mockQstashServer({
+        // eslint-disable-next-line @typescript-eslint/require-await
+        execute: async () => {
+          expect(context.executor.getParallelCallState(2, 1)).toBe("last");
+          expect(context.executor.stepCount).toBe(0);
+          expect(context.executor.planStepCount).toBe(0);
+          const result = await Promise.all([
+            context.sleep("sleep for some time", 123),
+            context.sleepUntil("sleep until next day", 123_123),
+          ]);
+          expect(result).toEqual([undefined, undefined]);
+          expect(context.executor.stepCount).toBe(2);
+          expect(context.executor.planStepCount).toBe(2);
+          expect(context.executor.getParallelCallState(2, 3)).toBe("first");
+        },
+        responseFields: {
+          status: 200,
+          body: "msgId",
+        },
+        receivesRequest: false,
+      });
+
+      expect(spyRunSingle).toHaveBeenCalledTimes(0);
+
+      expect(spyRunParallel).toHaveBeenCalledTimes(1);
+      const lazySteps = spyRunParallel.mock.calls[0][0];
+      expect(lazySteps.length).toBe(2);
+      expect(lazySteps[0].stepType).toBe("SleepFor");
+      expect(lazySteps[1].stepType).toBe("SleepUntil");
+      expect(lazySteps[0].stepName).toBe("sleep for some time");
+      expect(lazySteps[1].stepName).toBe("sleep until next day");
+    });
+  });
+});

--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -72,7 +72,7 @@ export class AutoExecutor {
    * @param lazyStep lazy step to execute
    * @returns step result
    */
-  private async runSingle<TResult>(lazyStep: BaseLazyStep<TResult>) {
+  protected async runSingle<TResult>(lazyStep: BaseLazyStep<TResult>) {
     if (this.stepCount < this.context.nonPlanStepCount) {
       const step = this.context.steps[this.stepCount + this.planStepCount];
       validateStep(lazyStep, step);
@@ -103,7 +103,7 @@ export class AutoExecutor {
    * @param stepFunctions list of async functions to run in parallel
    * @returns results of the functions run in parallel
    */
-  private async runParallel<TResults extends unknown[]>(parallelSteps: {
+  protected async runParallel<TResults extends unknown[]>(parallelSteps: {
     [K in keyof TResults]: BaseLazyStep<TResults[K]>;
   }): Promise<TResults> {
     // get the step count before the parallel steps were added + 1
@@ -277,7 +277,7 @@ export class AutoExecutor {
       );
     }
 
-    await this.debug?.log("INFO", "SUBMIT_STEP", { length: steps.length, steps });
+    await this.debug?.log("SUBMIT", "SUBMIT_STEP", { length: steps.length, steps });
 
     const result = await this.context.client.batchJSON(
       steps.map((singleStep) => {

--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -3,18 +3,21 @@ import type { WorkflowContext } from "./context";
 import type { ParallelCallState, Step } from "./types";
 import { type BaseLazyStep } from "./steps";
 import { getHeaders } from "./workflow-requests";
+import type { WorkflowLogger } from "./logger";
 
 export class AutoExecutor {
   private context: WorkflowContext;
   private promises = new WeakMap<BaseLazyStep[], Promise<unknown>>();
   private activeLazyStepList?: BaseLazyStep[];
+  private debug?: WorkflowLogger;
 
   private indexInCurrentList = 0;
   public stepCount = 0;
   public planStepCount = 0;
 
-  constructor(context: WorkflowContext) {
+  constructor(context: WorkflowContext, debug?: WorkflowLogger) {
     this.context = context;
+    this.debug = debug;
   }
 
   /**
@@ -73,10 +76,21 @@ export class AutoExecutor {
     if (this.stepCount < this.context.nonPlanStepCount) {
       const step = this.context.steps[this.stepCount + this.planStepCount];
       validateStep(lazyStep, step);
+      await this.debug?.log("INFO", "RUN_SINGLE", {
+        fromRequest: true,
+        step,
+        stepCount: this.stepCount,
+      });
       return step.out as TResult;
     }
 
     const resultStep = await lazyStep.getResultStep(this.stepCount, true);
+
+    await this.debug?.log("INFO", "RUN_SINGLE", {
+      fromRequest: false,
+      step: resultStep,
+      stepCount: this.stepCount,
+    });
     await this.submitStepsToQstash([resultStep]);
 
     return resultStep.out as TResult;
@@ -110,6 +124,14 @@ export class AutoExecutor {
           ` Expected ${parallelSteps.length}, got ${plannedParallelStepCount} from the request.`
       );
     }
+
+    await this.debug?.log("INFO", "RUN_PARALLEL", {
+      parallelCallState,
+      initialStepCount,
+      plannedParallelStepCount,
+      stepCount: this.stepCount,
+      planStepCount: this.planStepCount,
+    });
 
     switch (parallelCallState) {
       case "first": {
@@ -255,7 +277,9 @@ export class AutoExecutor {
       );
     }
 
-    await this.context.client.batchJSON(
+    await this.debug?.log("INFO", "SUBMIT_STEP", { length: steps.length, steps });
+
+    const result = await this.context.client.batchJSON(
       steps.map((singleStep) => {
         const headers = getHeaders(
           "false",
@@ -290,6 +314,14 @@ export class AutoExecutor {
             };
       })
     );
+
+    await this.debug?.log("INFO", "SUBMIT_STEP", {
+      messageIds: result.map((message) => {
+        return {
+          message: message.messageId,
+        };
+      }),
+    });
 
     // if the steps are sent successfully, abort to stop the current request
     throw new QstashWorkflowAbort(steps[0].stepName, steps[0]);

--- a/src/client/workflow/context.ts
+++ b/src/client/workflow/context.ts
@@ -3,9 +3,11 @@ import type { Client } from "../client";
 import { AutoExecutor } from "./auto-executor";
 import { LazyCallStep, LazyFunctionStep, LazySleepStep, LazySleepUntilStep } from "./steps";
 import type { HTTPMethods } from "../types";
+import type { WorkflowLogger } from "./logger";
 
 export class WorkflowContext<TInitialPayload = unknown> {
   protected readonly executor: AutoExecutor;
+
   public readonly client: Client;
   public readonly workflowId: string;
   public readonly steps: Step[];
@@ -21,6 +23,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     headers,
     steps,
     url,
+    debug,
   }: {
     client: Client;
     workflowId: string;
@@ -28,6 +31,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     headers: Headers;
     steps: Step[];
     url: string;
+    debug?: WorkflowLogger;
   }) {
     this.client = client;
     this.workflowId = workflowId;
@@ -37,7 +41,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     this.headers = headers;
     this.nonPlanStepCount = this.steps.filter((step) => !step.targetStep).length;
 
-    this.executor = new AutoExecutor(this);
+    this.executor = new AutoExecutor(this, debug);
   }
 
   /**

--- a/src/client/workflow/index.ts
+++ b/src/client/workflow/index.ts
@@ -1,3 +1,4 @@
 export * from "./serve";
 export * from "./context";
 export * from "./types";
+export * from "./logger";

--- a/src/client/workflow/integration.sh
+++ b/src/client/workflow/integration.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Check if enough arguments are provided
+if [ $# -lt 2 ]; then
+    echo "Please provide two arguments: MOCK_QSTASH_URL and MOCK_QSTASH_TOKEN."
+    echo "Usage: $0 <MOCK_QSTASH_URL> <MOCK_QSTASH_TOKEN>"
+    exit 1
+fi
+
+# Store the provided arguments
+MOCK_QSTASH_URL="$1"
+MOCK_QSTASH_TOKEN="$2"
+
+echo "INFO: starting ngrok tunnel"
+
+# Start ngrok with the provided configuration file
+ngrok start --all --config integration.yml --log=stdout > ngrok.log &
+NGROK_PID=$!
+sleep 5  # Allow some time for ngrok to start
+
+echo "INFO: ngrok tunnel started."
+
+# Extract the ngrok URLs from the logs
+ngrok_url_3000=$(grep -o 'url=https://[a-zA-Z0-9.-]*\.ngrok-free\.app' ngrok.log | grep -m 1 -o 'https://[a-zA-Z0-9.-]*\.ngrok-free\.app' | head -n1)
+ngrok_url_3001=$(grep -o 'url=https://[a-zA-Z0-9.-]*\.ngrok-free\.app' ngrok.log | grep -m 2 -o 'https://[a-zA-Z0-9.-]*\.ngrok-free\.app' | tail -n1)
+
+
+# Update the integration.test.ts file
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' 's/\.skip//g' integration.test.ts
+    sed -i '' "s|const LOCAL_WORKFLOW_URL = .*|const LOCAL_WORKFLOW_URL = '$ngrok_url_3000';|" integration.test.ts
+    sed -i '' "s|const LOCAL_THIRD_PARTY_URL = .*|const LOCAL_THIRD_PARTY_URL = '$ngrok_url_3001';|" integration.test.ts
+else
+    sed -i 's/\.skip//g' integration.test.ts
+    sed -i "s|const LOCAL_WORKFLOW_URL = .*|const LOCAL_WORKFLOW_URL = '$ngrok_url_3000';|" integration.test.ts
+    sed -i "s|const LOCAL_THIRD_PARTY_URL = .*|const LOCAL_THIRD_PARTY_URL = '$ngrok_url_3001';|" integration.test.ts
+fi
+
+echo "INFO: integration.test.ts updated."
+
+# Set environment variables
+export MOCK_QSTASH_URL="$MOCK_QSTASH_URL"
+export MOCK_QSTASH_TOKEN="$MOCK_QSTASH_TOKEN"
+
+echo "INFO: running tests."
+
+# Run integration tests
+bun test integration.test.ts --bail
+
+# Wait for ngrok process to be manually stopped
+wait $NGROK_PID

--- a/src/client/workflow/integration.test.ts
+++ b/src/client/workflow/integration.test.ts
@@ -1,0 +1,394 @@
+/**
+ * # End-to-end workflow tests
+ *
+ * In these tests, we define workflow endpoints using QStash serve method and
+ * creating an HTTP server with them (see `testEndpoint` method). After creating
+ * the workflow endpoint, `testEndpoint` makes the initial request to the endpoint.
+ *
+ * Endpoint calls QStash and a workflow execution commences. We wait for some time
+ * before killing the server. After killing the server, we check:
+ * - the number of times the endpoint was called
+ * - whether the route reached it's end (see `FinishState`)
+ *
+ * # How to run
+ *
+ * Since these tests require a local tunnel or a local QStash server, we can't run
+ * them in CI. So they are skipped. But they are still useful for local development.
+ *
+ * ## With Local QStash Server
+ *
+ * To run the tests, you can locally run the QStash server at localhost:8000.
+ *
+ * ## With Ngrok
+ *
+ * alternative to running QStash locally is to expose the localhost endpoints
+ * with local tunneling using Ngrok. The following ports should be exposed to
+ * the internet:
+ * - localhost:3000 (for LOCAL_WORKFLOW_URL)
+ * - localhost:3001 (for LOCAL_THIRD_PARTY_URL)
+ *
+ * Then, you should set the values of LOCAL_WORKFLOW_UR and LOCAL_THIRD_PARTY_URL
+ * with the Ngrok endpoints
+ */
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+/* eslint-disable prefer-const */
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+import { serve } from "bun";
+import { serve as workflowServe } from "./serve";
+import { expect, test, describe } from "bun:test";
+import { Client } from "../client";
+import type { WorkflowContext } from "./context";
+
+const WORKFLOW_PORT = "3000";
+const THIRD_PARTY_PORT = "3001";
+const LOCAL_WORKFLOW_URL = `http://localhost:${WORKFLOW_PORT}`;
+const LOCAL_THIRD_PARTY_URL = `http://localhost:${THIRD_PARTY_PORT}`;
+const NGROK_WORKFLOW_URL: string | undefined = undefined;
+const WORKFLOW_URL = NGROK_WORKFLOW_URL ?? LOCAL_WORKFLOW_URL;
+
+const someWork = (input: string) => {
+  return `processed '${input}'`;
+};
+
+type Invoice = {
+  date: number;
+  email: string;
+  amount: number;
+};
+
+type Charge = {
+  invoice: Invoice;
+  success: boolean;
+};
+
+class FinishState {
+  public finished = false;
+  public finish() {
+    this.finished = true;
+  }
+  public check() {
+    expect(this.finished).toBeTrue();
+  }
+}
+
+let counter = 0;
+const attemptCharge = () => {
+  counter += 1;
+  if (counter === 3) {
+    counter = 0;
+    return true;
+  }
+  return false;
+};
+
+const client = new Client({
+  baseUrl: process.env.MOCK_QSTASH_URL,
+  token: process.env.MOCK_QSTASH_TOKEN ?? "",
+});
+
+const testEndpoint = async <TInitialPayload = unknown>({
+  finalCount,
+  waitFor,
+  initialPayload,
+  routeFunction,
+  finishState,
+}: {
+  finalCount: number;
+  waitFor: number;
+  initialPayload: TInitialPayload;
+  routeFunction: (context: WorkflowContext<TInitialPayload>) => Promise<void>;
+  finishState: FinishState;
+}) => {
+  let counter = 0;
+
+  const endpoint = workflowServe<TInitialPayload>({
+    routeFunction,
+    options: {
+      client,
+      url: WORKFLOW_URL,
+      verbose: false,
+    },
+  });
+
+  const server = serve({
+    async fetch(request) {
+      counter += 1;
+      return await endpoint(request);
+    },
+    port: WORKFLOW_PORT,
+  });
+
+  // make the initial request:
+  const body = initialPayload
+    ? typeof initialPayload === "string"
+      ? initialPayload
+      : JSON.stringify(initialPayload)
+    : undefined;
+  await fetch(WORKFLOW_URL, {
+    method: "POST",
+    body,
+    headers: {
+      Authentication: "Bearer secretPassword",
+    },
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, waitFor));
+
+  server.stop();
+
+  finishState.check();
+  expect(counter).toBe(finalCount);
+};
+
+describe.skip("live serve tests", () => {
+  test(
+    "path endpoint",
+    async () => {
+      const finishState = new FinishState();
+      await testEndpoint({
+        finalCount: 4,
+        waitFor: 5000,
+        initialPayload: "my-payload",
+        finishState,
+        routeFunction: async (context) => {
+          const input = context.requestPayload;
+
+          expect(input).toBe("my-payload");
+
+          const result1 = await context.run("step1", async () => {
+            return await Promise.resolve(someWork(input));
+          });
+
+          expect(result1).toBe("processed 'my-payload'");
+
+          const result2 = await context.run("step2", async () => {
+            // console.log("step2 ran", result1);
+            const result = someWork(result1);
+            return await Promise.resolve(result);
+          });
+
+          expect(result2).toBe("processed 'processed 'my-payload''");
+          finishState.finish();
+        },
+      });
+    },
+    {
+      timeout: 10_000,
+    }
+  );
+
+  test(
+    "path sleep",
+
+    async () => {
+      const finishState = new FinishState();
+      await testEndpoint({
+        finalCount: 6,
+        waitFor: 20_000,
+        initialPayload: undefined,
+        finishState,
+        routeFunction: async (context) => {
+          const input = context.requestPayload;
+          expect(input).toBeUndefined();
+
+          const result1 = await context.run("step1", async () => {
+            const output = 123;
+            return output;
+          });
+          expect(result1).toBe(123);
+
+          await context.sleepUntil("sleep1", Date.now() / 1000 + 3);
+
+          const result2 = await context.run("step2", async () => {
+            const output = 234;
+            return output;
+          });
+          expect(result2).toBe(234);
+
+          await context.sleep("sleep2", 2);
+
+          const result3 = await context.run("step3", async () => {
+            const output = 345;
+            return output;
+          });
+          expect(result3).toBe(345);
+          finishState.finish();
+        },
+      });
+    },
+    {
+      timeout: 25_000,
+    }
+  );
+
+  test(
+    "sleepWithoutAwait endpoint",
+    async () => {
+      const payload = { date: 123, email: "my@mail.com", amount: 10 };
+      const finishState = new FinishState();
+      await testEndpoint<Invoice>({
+        finalCount: 13,
+        waitFor: 20_000,
+        initialPayload: payload,
+        finishState,
+        routeFunction: async (context) => {
+          const invoice = context.requestPayload;
+          expect(invoice).toEqual(payload);
+
+          for (let index = 0; index < 3; index++) {
+            const charge = await context.run("attemptCharge", async () => {
+              const success = attemptCharge();
+              const charge: Charge = { invoice, success };
+              return charge;
+            });
+
+            if (charge.success) {
+              const [updateDb, receipt, sleepResult] = await Promise.all([
+                context.run("updateDb", async () => {
+                  return charge.invoice.amount;
+                }),
+                context.run("sendReceipt", async () => {
+                  return charge.invoice.email;
+                }),
+                context.sleep("sleep", 5),
+              ]);
+              expect(updateDb).toBe(10);
+              expect(receipt).toBe("my@mail.com");
+              expect(sleepResult).toBeUndefined();
+              finishState.finish();
+              return;
+            }
+            await context.sleep("retrySleep", 2);
+          }
+          await context.run("paymentFailed", async () => {
+            return true;
+          });
+        },
+      });
+    },
+    {
+      timeout: 25_000,
+    }
+  );
+
+  test(
+    "auth endpoint",
+    async () => {
+      const finishState = new FinishState();
+      await testEndpoint({
+        finalCount: 4,
+        waitFor: 5000,
+        initialPayload: "my-payload",
+        finishState,
+        routeFunction: async (context) => {
+          if (context.headers.get("authentication") !== "Bearer secretPassword") {
+            console.error("Authentication failed.");
+            return;
+          }
+
+          const input = context.requestPayload;
+
+          expect(input).toBe("my-payload");
+
+          const result1 = await context.run("step1", async () => {
+            return await Promise.resolve(someWork(input));
+          });
+
+          expect(result1).toBe("processed 'my-payload'");
+
+          const result2 = await context.run("step2", async () => {
+            // console.log("step2 ran", result1);
+            const result = someWork(result1);
+            return await Promise.resolve(result);
+          });
+
+          expect(result2).toBe("processed 'processed 'my-payload''");
+          finishState.finish();
+        },
+      });
+    },
+    {
+      timeout: 10_000,
+    }
+  );
+
+  test(
+    "call endpoint",
+    async () => {
+      const thirdPartyResult = "third-party-result";
+      const postHeader = {
+        "post-header": "post-header-value-x",
+      };
+      const getHeader = {
+        "get-header": "get-header-value-x",
+      };
+      const thirdPartyServer = serve({
+        async fetch(request) {
+          if (request.method === "GET") {
+            return new Response(
+              `called GET '${thirdPartyResult}' '${request.headers.get("get-header")}'`,
+              {
+                status: 200,
+              }
+            );
+          } else if (request.method === "POST") {
+            return new Response(
+              `called POST '${thirdPartyResult}' '${request.headers.get("post-header")}' '${await request.text()}'`,
+              {
+                status: 200,
+              }
+            );
+          } else {
+            return new Response("method not allowed", { status: 400 });
+          }
+        },
+        port: THIRD_PARTY_PORT,
+      });
+
+      const finishState = new FinishState();
+      await testEndpoint({
+        finalCount: 6,
+        waitFor: 10_000,
+        initialPayload: "my-payload",
+        finishState,
+        routeFunction: async (context) => {
+          if (context.headers.get("authentication") !== "Bearer secretPassword") {
+            console.error("Authentication failed.");
+            return;
+          }
+
+          const postResult = await context.call<string>(
+            "post call",
+            LOCAL_THIRD_PARTY_URL,
+            "POST",
+            "post-payload",
+            postHeader
+          );
+          expect(postResult).toBe(
+            "called POST 'third-party-result' 'post-header-value-x' '\"post-payload\"'"
+          );
+
+          await context.sleep("sleep 1", 2);
+
+          const getResult = await context.call<string>(
+            "get call",
+            LOCAL_THIRD_PARTY_URL,
+            "GET",
+            undefined,
+            getHeader
+          );
+
+          expect(getResult).toBe("called GET 'third-party-result' 'get-header-value-x'");
+          finishState.finish();
+        },
+      });
+
+      thirdPartyServer.stop();
+    },
+    {
+      timeout: 15_000,
+    }
+  );
+});

--- a/src/client/workflow/integration.yml
+++ b/src/client/workflow/integration.yml
@@ -1,0 +1,9 @@
+authtoken: <auth-token>
+version: 2
+tunnels:
+  first:
+    addr: 3000
+    proto: http
+  second:
+    addr: 3001
+    proto: http

--- a/src/client/workflow/logger.ts
+++ b/src/client/workflow/logger.ts
@@ -1,0 +1,81 @@
+const LOG_LEVELS = ["DEBUG", "INFO", "WARN", "ERROR"] as const;
+type LogLevel = (typeof LOG_LEVELS)[number];
+type ChatLogEntry = {
+  timestamp: number;
+  logLevel: LogLevel;
+  eventType:
+    | "ENDPOINT_START" // when the endpoint is called
+    | "SUBMIT_THIRD_PARTY_RESULT" // third party call result
+    | "CREATE_CONTEXT" // isFirstInvocation, workflowId, headers, url and initialPayload and steps (steps only in DEBUG)
+    | "SUBMIT_FIRST_INVOCATION" // if triggerFirstInvocation is called
+    | "RUN_SINGLE"
+    | "RUN_PARALLEL"
+    | "SUBMIT_STEP"
+    | "SUBMIT_CLEANUP" // cleanup when a workflow ends
+    | "RESPONSE_WORKFLOW" // when onStepFinish is called with workflowId
+    | "RESPONSE_DEFAULT" // when onStepFinish("no-workflow-id") is called
+    | "ERROR"; // when onStepFinish("no-workflow-id") is called
+  details: unknown;
+};
+type WorkflowLoggerOptions = {
+  logLevel: LogLevel;
+  logOutput: "console";
+};
+
+export class WorkflowLogger {
+  private logs: ChatLogEntry[] = [];
+  private options: WorkflowLoggerOptions;
+
+  constructor(options: WorkflowLoggerOptions) {
+    this.options = options;
+  }
+
+  public async log(
+    level: LogLevel,
+    eventType: ChatLogEntry["eventType"],
+    details?: unknown
+  ): Promise<void> {
+    if (this.shouldLog(level)) {
+      const timestamp = Date.now();
+      const logEntry: ChatLogEntry = {
+        timestamp,
+        logLevel: level,
+        eventType,
+        details,
+      };
+
+      this.logs.push(logEntry);
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (this.options.logOutput === "console") {
+        this.writeToConsole(logEntry);
+      }
+
+      // Introduce a small delay to make the sequence more visible
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+
+  private writeToConsole(logEntry: ChatLogEntry): void {
+    const JSON_SPACING = 2;
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(logEntry, undefined, JSON_SPACING));
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    const levels: LogLevel[] = ["DEBUG", "INFO", "WARN", "ERROR"];
+    return levels.indexOf(level) >= levels.indexOf(this.options.logLevel);
+  }
+
+  public static getLogger(verbose: boolean | WorkflowLogger) {
+    if (typeof verbose === "object") {
+      return verbose;
+    } else {
+      return verbose
+        ? new WorkflowLogger({
+            logLevel: "INFO",
+            logOutput: "console",
+          })
+        : undefined;
+    }
+  }
+}

--- a/src/client/workflow/logger.ts
+++ b/src/client/workflow/logger.ts
@@ -1,5 +1,5 @@
 const LOG_LEVELS = ["DEBUG", "INFO", "SUBMIT", "WARN", "ERROR"] as const;
-type LogLevel = (typeof LOG_LEVELS)[number];
+export type LogLevel = (typeof LOG_LEVELS)[number];
 type ChatLogEntry = {
   timestamp: number;
   logLevel: LogLevel;
@@ -17,7 +17,7 @@ type ChatLogEntry = {
     | "ERROR"; // when onStepFinish("no-workflow-id") is called
   details: unknown;
 };
-type WorkflowLoggerOptions = {
+export type WorkflowLoggerOptions = {
   logLevel: LogLevel;
   logOutput: "console";
 };

--- a/src/client/workflow/logger.ts
+++ b/src/client/workflow/logger.ts
@@ -1,4 +1,4 @@
-const LOG_LEVELS = ["DEBUG", "INFO", "WARN", "ERROR"] as const;
+const LOG_LEVELS = ["DEBUG", "INFO", "SUBMIT", "WARN", "ERROR"] as const;
 type LogLevel = (typeof LOG_LEVELS)[number];
 type ChatLogEntry = {
   timestamp: number;
@@ -62,8 +62,7 @@ export class WorkflowLogger {
   }
 
   private shouldLog(level: LogLevel): boolean {
-    const levels: LogLevel[] = ["DEBUG", "INFO", "WARN", "ERROR"];
-    return levels.indexOf(level) >= levels.indexOf(this.options.logLevel);
+    return LOG_LEVELS.indexOf(level) >= LOG_LEVELS.indexOf(this.options.logLevel);
   }
 
   public static getLogger(verbose: boolean | WorkflowLogger) {

--- a/src/client/workflow/serve.test.ts
+++ b/src/client/workflow/serve.test.ts
@@ -1,0 +1,165 @@
+/* eslint-disable unicorn/no-null */
+/* eslint-disable @typescript-eslint/require-await */
+import { describe, test } from "bun:test";
+import { serve } from "./serve";
+import {
+  driveWorkflow,
+  getRequest,
+  MOCK_QSTASH_SERVER_URL,
+  mockQstashServer,
+  WORKFLOW_ENDPOINT,
+} from "./test-utils";
+import { nanoid } from "nanoid";
+import { Client } from "../client";
+import type { Step } from "./types";
+import { WORKFLOW_INIT_HEADER, WORKFLOW_PROTOCOL_VERSION_HEADER } from "./constants";
+
+const someWork = (input: string) => {
+  return `processed '${input}'`;
+};
+
+const workflowId = `wf${nanoid()}`;
+const token = nanoid();
+
+const client = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
+
+describe("serve", () => {
+  test("should send create workflow request in initial request", async () => {
+    const endpoint = serve<string>({
+      routeFunction: async (context) => {
+        const _input = context.requestPayload;
+      },
+      options: {
+        client,
+        verbose: true,
+      },
+    });
+
+    const initialPayload = nanoid();
+    const request = new Request(WORKFLOW_ENDPOINT, { method: "POST", body: initialPayload });
+    await mockQstashServer({
+      execute: async () => {
+        await endpoint(request);
+      },
+      responseFields: { body: "msgId", status: 200 },
+      receivesRequest: {
+        method: "POST",
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/publish/${WORKFLOW_ENDPOINT}`,
+        token,
+        body: initialPayload,
+        headers: {
+          [WORKFLOW_INIT_HEADER]: "true",
+          [WORKFLOW_PROTOCOL_VERSION_HEADER]: null,
+          [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: "1",
+        },
+      },
+    });
+  });
+
+  test.only("path endpoint", async () => {
+    const endpoint = serve<string>({
+      routeFunction: async (context) => {
+        const input = context.requestPayload;
+
+        const result1 = await context.run("step1", async () => {
+          return someWork(input);
+        });
+
+        await context.run("step2", async () => {
+          const result = someWork(result1);
+          return result;
+        });
+      },
+      options: {
+        client,
+        verbose: true,
+      },
+    });
+
+    const initialPayload = "initial-payload";
+    const steps: Step[] = [
+      {
+        stepId: 1,
+        stepName: "step1",
+        stepType: "Run",
+        out: `processed '${initialPayload}'`,
+        concurrent: 1,
+        targetStep: 0,
+      },
+      {
+        stepId: 2,
+        stepName: "step2",
+        stepType: "Run",
+        out: `processed 'processed '${initialPayload}''`,
+        concurrent: 1,
+        targetStep: 0,
+      },
+    ];
+
+    await driveWorkflow({
+      execute: async (initialPayload, steps) => {
+        const request = getRequest(WORKFLOW_ENDPOINT, workflowId, initialPayload, steps);
+        await endpoint(request);
+      },
+      initialPayload,
+      iterations: [
+        {
+          stepsToAdd: [],
+          responseFields: { body: { messageId: "some-message-id" }, status: 200 },
+          receivesRequest: {
+            method: "POST",
+            url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+            token,
+            body: [
+              {
+                body: JSON.stringify(steps[0]),
+                destination: WORKFLOW_ENDPOINT,
+                headers: {
+                  "content-type": "application/json",
+                  "upstash-forward-upstash-workflow-sdk-version": "1",
+                  "upstash-method": "POST",
+                  "upstash-workflow-id": workflowId,
+                  "upstash-workflow-init": "false",
+                  "upstash-workflow-url": WORKFLOW_ENDPOINT,
+                },
+              },
+            ],
+          },
+        },
+        {
+          stepsToAdd: [steps[0]],
+          responseFields: { body: { messageId: "some-message-id" }, status: 200 },
+          receivesRequest: {
+            method: "POST",
+            url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+            token,
+            body: [
+              {
+                destination: WORKFLOW_ENDPOINT,
+                headers: {
+                  "content-type": "application/json",
+                  "upstash-forward-upstash-workflow-sdk-version": "1",
+                  "upstash-method": "POST",
+                  "upstash-workflow-id": workflowId,
+                  "upstash-workflow-init": "false",
+                  "upstash-workflow-url": WORKFLOW_ENDPOINT,
+                },
+                body: JSON.stringify(steps[1]),
+              },
+            ],
+          },
+        },
+        {
+          stepsToAdd: [steps[1]],
+          responseFields: { body: "msgId", status: 200 },
+          receivesRequest: {
+            method: "DELETE",
+            url: `${MOCK_QSTASH_SERVER_URL}/v2/workflows/${workflowId}?cancel=false`,
+            token,
+            body: undefined,
+          },
+        },
+      ],
+    });
+  });
+});

--- a/src/client/workflow/serve.ts
+++ b/src/client/workflow/serve.ts
@@ -40,7 +40,23 @@ const processOptions = <TResponse = Response, TInitialPayload = unknown>(
     initialPayloadParser:
       options?.initialPayloadParser ??
       ((initialRequest: string) => {
-        return (initialRequest ? JSON.parse(initialRequest) : undefined) as TInitialPayload;
+        // if there is no payload, simply return undefined
+        if (!initialRequest) {
+          return undefined as TInitialPayload;
+        }
+
+        // try to parse the payload
+        try {
+          return JSON.parse(initialRequest) as TInitialPayload;
+        } catch (error) {
+          // if you get an error when parsing, return it as it is
+          // needed in plain string case.
+          if (error instanceof SyntaxError) {
+            return initialRequest as TInitialPayload;
+          }
+          // if not JSON.parse error, throw error
+          throw error;
+        }
       }),
     url: options?.url ?? "",
     verbose: options?.verbose ?? false,

--- a/src/client/workflow/steps.test.ts
+++ b/src/client/workflow/steps.test.ts
@@ -1,0 +1,173 @@
+import { describe, test, expect } from "bun:test";
+import { LazyCallStep, LazyFunctionStep, LazySleepStep, LazySleepUntilStep } from "./steps";
+import { nanoid } from "nanoid";
+import type { Step } from "./types";
+
+describe("test steps", () => {
+  const stepName = nanoid();
+  const concurrent = 10;
+  const targetStep = 7;
+  const stepId = 20;
+
+  describe("function step", () => {
+    const result = nanoid();
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    const stepFunction = async () => {
+      return await Promise.resolve(result);
+    };
+    const step = new LazyFunctionStep(stepName, stepFunction);
+
+    test("should set correct fields", () => {
+      expect(step.stepName).toBe(stepName);
+      expect(step.stepType).toBe("Run");
+    });
+    test("should create plan step", () => {
+      expect(step.getPlanStep(concurrent, targetStep)).toEqual({
+        stepId: 0,
+        stepName,
+        stepType: "Run",
+        concurrent,
+        targetStep,
+      });
+    });
+
+    test("should create result step", async () => {
+      const resultStep: Step<string> = {
+        stepId,
+        stepName,
+        stepType: "Run",
+        out: result,
+        concurrent: 1,
+        targetStep: 0,
+      };
+
+      // _singleStep has no affect:
+      expect(await step.getResultStep(stepId, false)).toEqual(resultStep);
+      expect(await step.getResultStep(stepId, true)).toEqual(resultStep);
+    });
+  });
+
+  describe("sleep step", () => {
+    const sleepAmount = 123_123;
+    const step = new LazySleepStep(stepName, sleepAmount);
+
+    test("should set correct fields", () => {
+      expect(step.stepName).toBe(stepName);
+      expect(step.stepType).toBe("SleepFor");
+    });
+    test("should create plan step", () => {
+      expect(step.getPlanStep(concurrent, targetStep)).toEqual({
+        stepId: 0,
+        stepName,
+        stepType: "SleepFor",
+        sleepFor: sleepAmount,
+        concurrent,
+        targetStep,
+      });
+    });
+
+    test("should create result step", async () => {
+      // if singleStep=false, then we are running parallel and the
+      // sleep was applied in the sleep step.
+      expect(await step.getResultStep(stepId, false)).toEqual({
+        stepId,
+        stepName,
+        stepType: "SleepFor",
+        concurrent: 1,
+        targetStep: 0,
+      });
+
+      // if singleStep=true, then we should sleep
+      expect(await step.getResultStep(stepId, true)).toEqual({
+        stepId,
+        stepName,
+        stepType: "SleepFor",
+        sleepFor: sleepAmount, // adding sleepFor
+        concurrent: 1,
+        targetStep: 0,
+      });
+    });
+  });
+
+  describe("sleepUntil step", () => {
+    const sleepUntilTime = 123_123;
+    const step = new LazySleepUntilStep(stepName, sleepUntilTime);
+
+    test("should set correct fields", () => {
+      expect(step.stepName).toBe(stepName);
+      expect(step.stepType).toBe("SleepUntil");
+    });
+    test("should create plan step", () => {
+      expect(step.getPlanStep(concurrent, targetStep)).toEqual({
+        stepId: 0,
+        stepName,
+        stepType: "SleepUntil",
+        sleepUntil: sleepUntilTime,
+        concurrent,
+        targetStep,
+      });
+    });
+
+    test("should create result step", async () => {
+      // if singleStep=false, then we are running parallel and the
+      // sleep was applied in the sleep step.
+      expect(await step.getResultStep(stepId, false)).toEqual({
+        stepId,
+        stepName,
+        stepType: "SleepUntil",
+        concurrent: 1,
+        targetStep: 0,
+      });
+
+      // if singleStep=true, then we should sleep
+      expect(await step.getResultStep(stepId, true)).toEqual({
+        stepId,
+        stepName,
+        stepType: "SleepUntil",
+        sleepUntil: sleepUntilTime, // adding sleepFor
+        concurrent: 1,
+        targetStep: 0,
+      });
+    });
+  });
+
+  describe("call step", () => {
+    const headerValue = nanoid();
+
+    const callUrl = "https://www.website.com/api";
+    const callMethod = "POST";
+    const callBody = nanoid();
+    const callHeaders = {
+      "my-header": headerValue,
+    };
+    const step = new LazyCallStep(stepName, callUrl, callMethod, callBody, callHeaders);
+
+    test("should set correct fields", () => {
+      expect(step.stepName).toBe(stepName);
+      expect(step.stepType).toBe("Call");
+    });
+    test("should create plan step", () => {
+      expect(step.getPlanStep(concurrent, targetStep)).toEqual({
+        stepId: 0,
+        stepName,
+        stepType: "Call",
+        concurrent,
+        targetStep,
+      });
+    });
+
+    test("should create result step", async () => {
+      expect(await step.getResultStep(stepId)).toEqual({
+        callBody,
+        callHeaders,
+        callMethod,
+        callUrl,
+        concurrent: 1,
+        stepId,
+        stepName,
+        stepType: "Call",
+        targetStep: 0,
+      });
+    });
+  });
+});

--- a/src/client/workflow/test-utils.ts
+++ b/src/client/workflow/test-utils.ts
@@ -1,0 +1,157 @@
+import { expect } from "bun:test";
+import { serve } from "bun";
+import type { RawStep, Step } from "./types";
+import {
+  WORKFLOW_ID_HEADER,
+  WORKFLOW_PROTOCOL_VERSION,
+  WORKFLOW_PROTOCOL_VERSION_HEADER,
+} from "./constants";
+
+export const MOCK_QSTASH_SERVER_PORT = 8080;
+export const MOCK_QSTASH_SERVER_URL = `http://localhost:${MOCK_QSTASH_SERVER_PORT}`;
+
+export const MOCK_SERVER_URL = "https://requestcatcher.com/";
+export const WORKFLOW_ENDPOINT = "https://www.my-website.com/api";
+
+export type ResponseFields = {
+  body: unknown;
+  status: number;
+};
+
+export type RequestFields = {
+  method: string;
+  url: string;
+  token: string;
+  body?: unknown;
+  headers?: Record<string, string | null>;
+};
+
+/**
+ * Create a HTTP client to mock QStash. We pass the URL of the mock server
+ * as baseUrl and verify that the request is as we expect.
+ *
+ * @param execute function which will call QStash
+ * @param responseFields body and status of the response QStash returns
+ * @param receivesRequest fields of the request sent to QStash as a result of running
+ *    `await execute()`. If set to false, we assert that no request is sent.
+ */
+export const mockQstashServer = async ({
+  execute,
+  responseFields,
+  receivesRequest,
+}: {
+  execute: () => Promise<unknown>;
+  responseFields: ResponseFields;
+  receivesRequest: RequestFields | false;
+}) => {
+  const shouldBeCalled = Boolean(receivesRequest);
+  let called = false;
+
+  const server = serve({
+    async fetch(request) {
+      called = true;
+
+      if (!receivesRequest) {
+        return new Response("assertion in mock QStash failed. fetch shouldn't have been called.", {
+          status: 400,
+        });
+      }
+      const { method, url, token, body } = receivesRequest;
+      try {
+        expect(request.method).toBe(method);
+        expect(request.url).toBe(url);
+        expect(request.headers.get("authorization")).toBe(`Bearer ${token}`);
+        // check body
+        if (body) {
+          expect(await request.json()).toEqual(body);
+        } else {
+          expect(await request.text()).toBeFalsy();
+        }
+        // check headers
+        if (receivesRequest.headers) {
+          for (const header in receivesRequest.headers) {
+            const value = receivesRequest.headers[header];
+            expect(request.headers.get(header)).toBe(value);
+          }
+        }
+      } catch (error) {
+        if (error instanceof Error) {
+          console.error("Assertion error:", error.message);
+          return new Response(`assertion in mock QStash failed.`, {
+            status: 400,
+          });
+        }
+      }
+      return new Response(JSON.stringify(responseFields.body), {
+        status: responseFields.status,
+      });
+    },
+    port: MOCK_QSTASH_SERVER_PORT,
+  });
+
+  try {
+    await execute();
+    expect(called).toBe(shouldBeCalled);
+  } finally {
+    server.stop(true);
+  }
+};
+
+type Iteration = {
+  stepsToAdd: Step[];
+  responseFields: ResponseFields;
+  receivesRequest: RequestFields | false;
+};
+
+type IterationTape = Iteration[];
+
+export const driveWorkflow = async ({
+  execute,
+  initialPayload,
+  iterations,
+}: {
+  execute: (intialPayload: unknown, steps: Step[]) => Promise<void>;
+  initialPayload: unknown;
+  iterations: IterationTape;
+}) => {
+  const steps: Step[] = [];
+  for (const { stepsToAdd, responseFields, receivesRequest } of iterations) {
+    steps.push(...stepsToAdd);
+    await mockQstashServer({
+      execute: () => execute(initialPayload, steps),
+      responseFields,
+      receivesRequest,
+    });
+  }
+};
+
+export const getRequest = (
+  workflowUrl: string,
+  workflowId: string,
+  initialPayload: unknown,
+  steps: Step[]
+): Request => {
+  const encodedInitialPayload = btoa(
+    typeof initialPayload === "string" ? initialPayload : JSON.stringify(initialPayload)
+  );
+  const encodedInitialStep: RawStep = {
+    messageId: "msgId",
+    body: encodedInitialPayload,
+    callType: "step",
+  };
+  const encodedSteps: RawStep[] = steps.map((step) => {
+    return {
+      messageId: "msgId",
+      body: btoa(JSON.stringify(step)),
+      callType: "step",
+    };
+  });
+
+  return new Request(workflowUrl, {
+    body: JSON.stringify([encodedInitialStep, ...encodedSteps]),
+    headers: {
+      [WORKFLOW_ID_HEADER]: workflowId,
+      [WORKFLOW_PROTOCOL_VERSION_HEADER]: WORKFLOW_PROTOCOL_VERSION,
+    },
+  });
+};

--- a/src/client/workflow/types.ts
+++ b/src/client/workflow/types.ts
@@ -1,6 +1,7 @@
 import type { Client } from "../client";
 import type { HTTPMethods } from "../types";
 import type { WorkflowContext } from "./context";
+import type { WorkflowLogger } from "./logger";
 
 export const StepTypes = ["Initial", "Run", "SleepFor", "SleepUntil", "Call"] as const;
 export type StepType = (typeof StepTypes)[number];
@@ -119,4 +120,8 @@ export type WorkflowServeOptions<TResponse = Response, TInitialPayload = unknown
    * If not set, url will be inferred from the request.
    */
   url?: string;
+  /**
+   * Verbose mode
+   */
+  verbose?: boolean | WorkflowLogger;
 };

--- a/src/client/workflow/types.ts
+++ b/src/client/workflow/types.ts
@@ -65,6 +65,12 @@ export type Step<TResult = unknown, TBody = unknown> = {
   targetStep: number;
 } & (ThirdPartyCallFields<TBody> | { [P in keyof ThirdPartyCallFields]?: never });
 
+export type RawStep = {
+  messageId: string;
+  body: string; // body is a base64 encoded step or payload
+  callType: "step" | "toCallback" | "fromCallback";
+};
+
 export type SyncStepFunction<TResult> = () => TResult;
 export type AsyncStepFunction<TResult> = () => Promise<TResult>;
 export type StepFunction<TResult> = AsyncStepFunction<TResult> | SyncStepFunction<TResult>;

--- a/src/client/workflow/workflow-parser.test.ts
+++ b/src/client/workflow/workflow-parser.test.ts
@@ -1,0 +1,203 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+import { describe, expect, test } from "bun:test";
+import { parseRequest, validateRequest } from "./workflow-parser";
+import {
+  WORKFLOW_ID_HEADER,
+  WORKFLOW_PROTOCOL_VERSION,
+  WORKFLOW_PROTOCOL_VERSION_HEADER,
+} from "./constants";
+import { nanoid } from "nanoid";
+import type { Step } from "./types";
+import { getRequest, WORKFLOW_ENDPOINT } from "./test-utils";
+
+describe("Workflow Parser", () => {
+  describe("validateRequest", () => {
+    test("should accept first invocation", () => {
+      const request = new Request(WORKFLOW_ENDPOINT, {
+        headers: undefined,
+      });
+
+      const { isFirstInvocation, workflowId } = validateRequest(request);
+
+      expect(isFirstInvocation).toBeTrue();
+      expect(workflowId.slice(0, 2)).toBe("wf");
+      expect(workflowId.length).toBeGreaterThan(2);
+    });
+
+    test("should ignore passed workflow header if first invocation", () => {
+      const requestWorkflowId = "wf-some-id";
+      const request = new Request(WORKFLOW_ENDPOINT, {
+        headers: {
+          [WORKFLOW_ID_HEADER]: requestWorkflowId,
+        },
+      });
+
+      const { isFirstInvocation, workflowId } = validateRequest(request);
+
+      expect(isFirstInvocation).toBeTrue();
+      // worklfow id in the request should be ignored
+      expect(workflowId !== requestWorkflowId).toBeTrue();
+    });
+
+    test("should throw when protocol header is given without workflow id header", () => {
+      const request = new Request(WORKFLOW_ENDPOINT, {
+        headers: {
+          [WORKFLOW_PROTOCOL_VERSION_HEADER]: WORKFLOW_PROTOCOL_VERSION,
+        },
+      });
+
+      const throws = () => validateRequest(request);
+      expect(throws).toThrow("Couldn't get workflow id from header");
+    });
+
+    test("should throw when protocol version is incompatible", () => {
+      const requestProtocol = "wrong-protocol";
+      const request = new Request(WORKFLOW_ENDPOINT, {
+        headers: {
+          [WORKFLOW_PROTOCOL_VERSION_HEADER]: requestProtocol,
+        },
+      });
+
+      const throws = () => validateRequest(request);
+      expect(throws).toThrow(
+        `Incompatible workflow sdk protocol version.` +
+          ` Expected ${WORKFLOW_PROTOCOL_VERSION}, got ${requestProtocol} from the request.`
+      );
+    });
+
+    test("should accept when called correctly", () => {
+      const requestWorkflowId = `wf${nanoid()}`;
+      const request = new Request(WORKFLOW_ENDPOINT, {
+        headers: {
+          [WORKFLOW_PROTOCOL_VERSION_HEADER]: WORKFLOW_PROTOCOL_VERSION,
+          [WORKFLOW_ID_HEADER]: requestWorkflowId,
+        },
+      });
+      const { isFirstInvocation, workflowId } = validateRequest(request);
+
+      expect(isFirstInvocation).toBeFalse();
+      expect(workflowId).toBe(requestWorkflowId);
+    });
+  });
+
+  describe("parseRequest", () => {
+    test("should handle first invocation", async () => {
+      const payload = { initial: "payload" };
+      const rawPayload = JSON.stringify(payload);
+      const request = new Request(WORKFLOW_ENDPOINT, {
+        body: rawPayload,
+      });
+      const { initialPayload, steps } = await parseRequest(request, true);
+
+      // payload isn't parsed
+      expect(typeof initialPayload).toBe("string");
+      expect(initialPayload).toBe(rawPayload);
+      // steps are empty:
+      expect(steps).toEqual([]);
+    });
+
+    test("should throw when not first invocation and body is missing", () => {
+      const request = new Request(WORKFLOW_ENDPOINT);
+      // isFirstInvocation = false:
+      const throws = parseRequest(request, false);
+      expect(throws).rejects.toThrow("Only first call can have an empty body");
+    });
+
+    test("should return steps and initial payload correctly", async () => {
+      const requestInitialPayload = { initial: "payload" };
+      const resultSteps: Step[] = [
+        {
+          stepId: 1,
+          stepName: "first step",
+          stepType: "Run",
+          out: "first result",
+          concurrent: 1,
+          targetStep: 1,
+        },
+        {
+          stepId: 1,
+          stepName: "first step",
+          stepType: "Run",
+          out: "second result",
+          concurrent: 1,
+          targetStep: 1,
+        },
+      ];
+
+      const request = getRequest(WORKFLOW_ENDPOINT, "wf-id", requestInitialPayload, resultSteps);
+      const { initialPayload, steps } = await parseRequest(request, false);
+
+      // payload is not parsed
+      expect(typeof initialPayload).toEqual("string");
+      expect(initialPayload).toEqual(JSON.stringify(requestInitialPayload));
+
+      // steps
+      expect(typeof steps).toBe("object");
+      const expectedSteps: Step[] = [
+        {
+          stepId: 0,
+          stepName: "init",
+          stepType: "Initial",
+          out: initialPayload,
+          targetStep: 0,
+          concurrent: 1,
+        },
+        ...resultSteps,
+      ];
+      expect(steps).toEqual(expectedSteps);
+
+      // first step body (which is initial payload) is also string,
+      // it's not parsed:
+      expect(typeof steps[0].out).toBe("string");
+    });
+
+    test("should filter out toCallback and fromCallback", async () => {
+      const reqiestInitialPayload = "initial payload";
+      const remainingStepId = 3;
+
+      const getEncodedStep: (stepId: number) => string = (stepId) => {
+        return btoa(
+          JSON.stringify({
+            stepId,
+            stepName: "step",
+            stepType: "Call",
+            out: "result",
+            concurrent: 1,
+            targetStep: 1,
+          })
+        );
+      };
+      const payload = [
+        {
+          messageId: "msgId",
+          body: btoa(reqiestInitialPayload),
+          callType: "step",
+        },
+        {
+          messageId: "msgId",
+          body: getEncodedStep(1),
+          callType: "toCallback",
+        },
+        {
+          messageId: "msgId",
+          body: getEncodedStep(2),
+          callType: "fromCallback",
+        },
+        {
+          messageId: "msgId",
+          body: getEncodedStep(remainingStepId),
+          callType: "step",
+        },
+      ];
+
+      const request = new Request(WORKFLOW_ENDPOINT, { body: JSON.stringify(payload) });
+      const { initialPayload, steps } = await parseRequest(request, false);
+
+      expect(initialPayload).toBe(reqiestInitialPayload);
+
+      expect(steps.length).toBe(2);
+      expect(steps[0].stepId).toBe(0);
+      expect(steps[1].stepId).toBe(remainingStepId);
+    });
+  });
+});

--- a/src/client/workflow/workflow-parser.ts
+++ b/src/client/workflow/workflow-parser.ts
@@ -4,7 +4,7 @@ import {
   WORKFLOW_PROTOCOL_VERSION,
   WORKFLOW_PROTOCOL_VERSION_HEADER,
 } from "./constants";
-import type { Step } from "./types";
+import type { RawStep, Step } from "./types";
 import { nanoid } from "nanoid";
 
 /**
@@ -45,11 +45,7 @@ const decodeBase64 = (encodedString: string) => {
  * @returns intiial payload and list of steps
  */
 const parsePayload = (rawPayload: string) => {
-  const [encodedInitialPayload, ...encodedSteps] = JSON.parse(rawPayload) as {
-    messageId: string;
-    body: string;
-    callType: "step" | "toCallback" | "fromCallback";
-  }[];
+  const [encodedInitialPayload, ...encodedSteps] = JSON.parse(rawPayload) as RawStep[];
 
   const stepsToDecode = encodedSteps.filter((step) => step.callType === "step");
 


### PR DESCRIPTION
This pr adds verbose mode and tests to workflow.

## Verbose mode

there is an option in `serve`:

```ts
export const POST = serve({
  routeFunction: ...,
  options: {
    verbose: true
  }
})
```

default value is false.

<details>
<summary>Logs from `path` endpoint (generated in `serve.test.ts`)</summary>

```
{
  "timestamp": 1722494819485,
  "logLevel": "INFO",
  "eventType": "ENDPOINT_START"
}
{
  "timestamp": 1722494819590,
  "logLevel": "INFO",
  "eventType": "RUN_SINGLE",
  "details": {
    "fromRequest": false,
    "step": {
      "stepId": 1,
      "stepName": "step1",
      "stepType": "Run",
      "out": "processed 'initial-payload'",
      "concurrent": 1,
      "targetStep": 0
    },
    "stepCount": 1
  }
}
{
  "timestamp": 1722494819695,
  "logLevel": "SUBMIT",
  "eventType": "SUBMIT_STEP",
  "details": {
    "length": 1,
    "steps": [
      {
        "stepId": 1,
        "stepName": "step1",
        "stepType": "Run",
        "out": "processed 'initial-payload'",
        "concurrent": 1,
        "targetStep": 0
      }
    ]
  }
}
{
  "timestamp": 1722494819800,
  "logLevel": "INFO",
  "eventType": "SUBMIT_STEP",
  "details": {
    "messageIds": [
      {
        "message": "some-message-id"
      }
    ]
  }
}
{
  "timestamp": 1722494819902,
  "logLevel": "INFO",
  "eventType": "RESPONSE_WORKFLOW",
  "details": {
    "workflowId": "wfNPKWYakU6jAgLaUIiP-5O"
  }
}
{
  "timestamp": 1722494820004,
  "logLevel": "INFO",
  "eventType": "ENDPOINT_START"
}
{
  "timestamp": 1722494820106,
  "logLevel": "INFO",
  "eventType": "RUN_SINGLE",
  "details": {
    "fromRequest": true,
    "step": {
      "stepId": 1,
      "stepName": "step1",
      "stepType": "Run",
      "out": "processed 'initial-payload'",
      "concurrent": 1,
      "targetStep": 0
    },
    "stepCount": 1
  }
}
{
  "timestamp": 1722494820208,
  "logLevel": "INFO",
  "eventType": "RUN_SINGLE",
  "details": {
    "fromRequest": false,
    "step": {
      "stepId": 2,
      "stepName": "step2",
      "stepType": "Run",
      "out": "processed 'processed 'initial-payload''",
      "concurrent": 1,
      "targetStep": 0
    },
    "stepCount": 2
  }
}
{
  "timestamp": 1722494820309,
  "logLevel": "SUBMIT",
  "eventType": "SUBMIT_STEP",
  "details": {
    "length": 1,
    "steps": [
      {
        "stepId": 2,
        "stepName": "step2",
        "stepType": "Run",
        "out": "processed 'processed 'initial-payload''",
        "concurrent": 1,
        "targetStep": 0
      }
    ]
  }
}
{
  "timestamp": 1722494820412,
  "logLevel": "INFO",
  "eventType": "SUBMIT_STEP",
  "details": {
    "messageIds": [
      {
        "message": "some-message-id"
      }
    ]
  }
}
{
  "timestamp": 1722494820514,
  "logLevel": "INFO",
  "eventType": "RESPONSE_WORKFLOW",
  "details": {
    "workflowId": "wfNPKWYakU6jAgLaUIiP-5O"
  }
}
{
  "timestamp": 1722494820616,
  "logLevel": "INFO",
  "eventType": "ENDPOINT_START"
}
{
  "timestamp": 1722494820718,
  "logLevel": "INFO",
  "eventType": "RUN_SINGLE",
  "details": {
    "fromRequest": true,
    "step": {
      "stepId": 1,
      "stepName": "step1",
      "stepType": "Run",
      "out": "processed 'initial-payload'",
      "concurrent": 1,
      "targetStep": 0
    },
    "stepCount": 1
  }
}
{
  "timestamp": 1722494820819,
  "logLevel": "INFO",
  "eventType": "RUN_SINGLE",
  "details": {
    "fromRequest": true,
    "step": {
      "stepId": 2,
      "stepName": "step2",
      "stepType": "Run",
      "out": "processed 'processed 'initial-payload''",
      "concurrent": 1,
      "targetStep": 0
    },
    "stepCount": 2
  }
}
{
  "timestamp": 1722494820921,
  "logLevel": "SUBMIT",
  "eventType": "SUBMIT_CLEANUP",
  "details": {
    "deletedWorkflowId": "wfNPKWYakU6jAgLaUIiP-5O"
  }
}
{
  "timestamp": 1722494821025,
  "logLevel": "SUBMIT",
  "eventType": "SUBMIT_CLEANUP"
}
{
  "timestamp": 1722494821126,
  "logLevel": "INFO",
  "eventType": "RESPONSE_WORKFLOW",
  "details": {
    "workflowId": "wfNPKWYakU6jAgLaUIiP-5O"
  }
}
```
</details>

## Tests

wrote unit tests for each file. There is a `test-utils.ts` file which has helper methods like:
 - `mockQstashServer`: gets an executable which makes a request to localhost:8080, starts a HTTP server at localhost:8080 and checks the request
 - `driveWorkflow`: given a workflow endpoint executable and iteration definitions, calls the endpoint multiple times and checks the request it sends using `mockQstashServer`.

There is also an `integration.test.ts` file, which is skipped in Github CI but can be run locally. It creates an HTTP server with a given workflow route and calls local QStash with it to test the endpoint end to end. There are more details in the docstring in the file.

Test coverage when integration tests are enabled:

File                  | % Funcs | % Lines | Uncovered Line #s
----------------------|---------|---------|-------------------
 auto-executor.ts     |   87.10 |  100.00 | 
 constants.ts         |  100.00 |  100.00 | 
 context.ts           |  100.00 |  100.00 | 
 logger.ts            |  100.00 |  100.00 | 
 serve.ts             |  100.00 |   93.42 | 56,106-107,132-133
 steps.ts             |  100.00 |  100.00 | 
 test-utils.ts        |  100.00 |   90.63 | 55-57,77-82
 types.ts             |  100.00 |  100.00 | 
 workflow-parser.ts   |  100.00 |   98.55 | 
 workflow-requests.ts |  100.00 |   90.50 | 153-163,199-204

## Other

- made a small change to `batch` method of the client. When the batch contained only one item, it returned `UpstashResponse` instead of `UpstashResponse[]`.  Now it always returns array.
- fixed a few issues in `getHeaders` and `handleThirdPartyCallResult`.
