### PR TITLE
fix: correct nextjs imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
       "require": "./index.js"
     },
     "./nextjs": {
-      "types": "./next.d.ts",
-      "import": "./next.mjs",
-      "require": "./next.js"
+      "types": "./nextjs.d.ts",
+      "import": "./nextjs.mjs",
+      "require": "./nextjs.js"
     },
     "./dist/nextjs": {
-      "types": "./next.d.ts",
-      "import": "./next.mjs",
-      "require": "./next.js"
+      "types": "./nextjs.d.ts",
+      "import": "./nextjs.mjs",
+      "require": "./nextjs.js"
     },
     "./nuxt": {
       "types": "./nuxt.d.ts",


### PR DESCRIPTION
they were changed from nextjs to next in https://github.com/upstash/qstash-js/commit/26a3b817b57f445e8c0b5312b7b0e30ea8be83c2