### PR TITLE
Workflow: Authenticaton & Failure Handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.5",
+  "version": "2.6.4-workflow-alpha.0",
   "name": "@upstash/qstash",
   "description": "Official Typescript client for QStash",
   "author": "Andreas Thomas <dev@chronark.com>",

--- a/src/client/workflow/auto-executor.test.ts
+++ b/src/client/workflow/auto-executor.test.ts
@@ -73,14 +73,16 @@ describe("auto-executor", () => {
       stepId: 1,
       stepName: "sleep for some time",
       stepType: "SleepFor",
-      concurrent: 1,
+      sleepFor: 123,
+      concurrent: 2,
       targetStep: 0,
     },
     {
       stepId: 2,
       stepName: "sleep until next day",
       stepType: "SleepUntil",
-      concurrent: 1,
+      sleepUntil: 123_123,
+      concurrent: 2,
       targetStep: 0,
     },
   ];

--- a/src/client/workflow/auto-executor.test.ts
+++ b/src/client/workflow/auto-executor.test.ts
@@ -40,7 +40,6 @@ describe("auto-executor", () => {
     stepType: "Initial",
     out: JSON.stringify(initialPayload),
     concurrent: 1,
-    targetStep: 0,
   };
 
   const singleStep: Step = {
@@ -49,7 +48,6 @@ describe("auto-executor", () => {
     stepType: "Run",
     out: { input: initialPayload, success: false },
     concurrent: 1,
-    targetStep: 0,
   };
 
   const parallelSteps: Step[] = [
@@ -75,7 +73,6 @@ describe("auto-executor", () => {
       stepType: "SleepFor",
       sleepFor: 123,
       concurrent: 2,
-      targetStep: 0,
     },
     {
       stepId: 2,
@@ -83,7 +80,6 @@ describe("auto-executor", () => {
       stepType: "SleepUntil",
       sleepUntil: 123_123,
       concurrent: 2,
-      targetStep: 0,
     },
   ];
 

--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -188,7 +188,7 @@ export class AutoExecutor {
          * Execute the step and call qstash with the result
          */
         const planStep = this.context.steps.at(-1);
-        if (!planStep || planStep.targetStep === 0) {
+        if (!planStep || planStep.targetStep === undefined) {
           throw new QstashWorkflowError(
             `There must be a last step and it should have targetStep larger than 0.` +
               `Received: ${JSON.stringify(planStep)}`
@@ -276,7 +276,7 @@ export class AutoExecutor {
     initialStepCount: number
   ): ParallelCallState {
     const remainingSteps = this.context.steps.filter(
-      (step) => (step.stepId === 0 ? step.targetStep : step.stepId) >= initialStepCount
+      (step) => (step.targetStep ?? step.stepId) >= initialStepCount
     );
 
     if (remainingSteps.length === 0) {
@@ -475,6 +475,6 @@ const validateParallelSteps = (lazySteps: BaseLazyStep[], stepsFromRequest: Step
  * @returns sorted steps
  */
 const sortSteps = (steps: Step[]): Step[] => {
-  const getStepId = (step: Step) => (step.stepId === 0 ? step.targetStep : step.stepId);
+  const getStepId = (step: Step) => step.targetStep ?? step.stepId;
   return steps.toSorted((step, stepOther) => getStepId(step) - getStepId(stepOther));
 };

--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -4,6 +4,7 @@ import type { AsyncStepFunction, ParallelCallState, Step } from "./types";
 import { type BaseLazyStep } from "./steps";
 import { getHeaders } from "./workflow-requests";
 import type { WorkflowLogger } from "./logger";
+import { NO_CONCURRENCY } from "./constants";
 
 export class AutoExecutor {
   private context: WorkflowContext;
@@ -121,7 +122,7 @@ export class AutoExecutor {
       return step.out as TResult;
     }
 
-    const resultStep = await lazyStep.getResultStep(1, this.stepCount);
+    const resultStep = await lazyStep.getResultStep(NO_CONCURRENCY, this.stepCount);
 
     await this.debug?.log("INFO", "RUN_SINGLE", {
       fromRequest: false,
@@ -328,7 +329,7 @@ export class AutoExecutor {
         );
 
         // if the step is a single step execution or a plan step, we can add sleep headers
-        const willWait = singleStep.concurrent === 1 || singleStep.stepId === 0;
+        const willWait = singleStep.concurrent === NO_CONCURRENCY || singleStep.stepId === 0;
 
         return singleStep.callUrl
           ? // if the step is a third party call, we call the third party

--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -323,7 +323,8 @@ export class AutoExecutor {
           this.context.workflowRunId,
           this.context.url,
           this.context.headers,
-          singleStep
+          singleStep,
+          this.context.failureUrl
         );
 
         // if the step is a single step execution or a plan step, we can add sleep headers

--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -421,15 +421,15 @@ const validateStep = (lazyStep: BaseLazyStep, stepFromRequest: Step): void => {
   // check step name
   if (lazyStep.stepName !== stepFromRequest.stepName) {
     throw new QstashWorkflowError(
-      `Incompatible step name. Expected ${lazyStep.stepName},` +
-        ` got ${stepFromRequest.stepName} from the request`
+      `Incompatible step name. Expected '${lazyStep.stepName}',` +
+        ` got '${stepFromRequest.stepName}' from the request`
     );
   }
   // check type name
   if (lazyStep.stepType !== stepFromRequest.stepType) {
     throw new QstashWorkflowError(
-      `Incompatible step type. Expected ${lazyStep.stepType},` +
-        ` got ${stepFromRequest.stepType} from the request`
+      `Incompatible step type. Expected '${lazyStep.stepType}',` +
+        ` got '${stepFromRequest.stepType}' from the request`
     );
   }
 };
@@ -457,10 +457,10 @@ const validateParallelSteps = (lazySteps: BaseLazyStep[], stepsFromRequest: Step
       const requestStepTypes = stepsFromRequest.map((step) => step.stepType);
       throw new QstashWorkflowError(
         `Incompatible steps detected in parallel execution: ${error.message}` +
-          `\n  > Step Names from the request: ${requestStepNames}` +
-          `\n    Step Types from the request: ${requestStepTypes}` +
-          `\n  > Step Names expected: ${lazyStepNames}` +
-          `\n    Step Types expected: ${lazyStepTypes}`
+          `\n  > Step Names from the request: ${JSON.stringify(requestStepNames)}` +
+          `\n    Step Types from the request: ${JSON.stringify(requestStepTypes)}` +
+          `\n  > Step Names expected: ${JSON.stringify(lazyStepNames)}` +
+          `\n    Step Types expected: ${JSON.stringify(lazyStepTypes)}`
       );
     }
     throw error;

--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -11,6 +11,7 @@ export class AutoExecutor {
   private activeLazyStepList?: BaseLazyStep[];
   private debug?: WorkflowLogger;
 
+  private readonly nonPlanStepCount: number;
   private indexInCurrentList = 0;
   public stepCount = 0;
   public planStepCount = 0;
@@ -20,6 +21,7 @@ export class AutoExecutor {
   constructor(context: WorkflowContext, debug?: WorkflowLogger) {
     this.context = context;
     this.debug = debug;
+    this.nonPlanStepCount = this.context.steps.filter((step) => !step.targetStep).length;
   }
 
   /**
@@ -108,7 +110,7 @@ export class AutoExecutor {
    * @returns step result
    */
   protected async runSingle<TResult>(lazyStep: BaseLazyStep<TResult>) {
-    if (this.stepCount < this.context.nonPlanStepCount) {
+    if (this.stepCount < this.nonPlanStepCount) {
       const step = this.context.steps[this.stepCount + this.planStepCount];
       validateStep(lazyStep, step);
       await this.debug?.log("INFO", "RUN_SINGLE", {

--- a/src/client/workflow/constants.ts
+++ b/src/client/workflow/constants.ts
@@ -7,3 +7,6 @@ export const WORKFLOW_PROTOCOL_VERSION = "1";
 export const WORKFLOW_PROTOCOL_VERSION_HEADER = "Upstash-Workflow-Sdk-Version";
 
 export const DEFAULT_CONTENT_TYPE = "application/json";
+
+export const NO_CONCURRENCY = 1;
+export const NOT_SET = "not-set";

--- a/src/client/workflow/constants.ts
+++ b/src/client/workflow/constants.ts
@@ -1,6 +1,7 @@
 export const WORKFLOW_ID_HEADER = "Upstash-Workflow-RunId";
 export const WORKFLOW_INIT_HEADER = "Upstash-Workflow-Init";
 export const WORKFLOW_URL_HEADER = "Upstash-Workflow-Url";
+export const WORKFLOW_FAILURE_HEADER = "Upstash-Workflow-Is-Failure";
 
 export const WORKFLOW_PROTOCOL_VERSION = "1";
 export const WORKFLOW_PROTOCOL_VERSION_HEADER = "Upstash-Workflow-Sdk-Version";

--- a/src/client/workflow/context.test.ts
+++ b/src/client/workflow/context.test.ts
@@ -5,6 +5,7 @@ import { MOCK_QSTASH_SERVER_URL, mockQstashServer, WORKFLOW_ENDPOINT } from "./t
 import { WorkflowContext } from "./context";
 import { Client } from "../client";
 import { nanoid } from "nanoid";
+import { QstashWorkflowError } from "../error";
 
 describe("context tests", () => {
   const token = nanoid();
@@ -27,7 +28,9 @@ describe("context tests", () => {
       });
     };
     expect(throws).toThrow(
-      "A step can not be run inside another step. Tried to run 'inner step' inside 'outer step'"
+      new QstashWorkflowError(
+        "A step can not be run inside another step. Tried to run 'inner step' inside 'outer step'"
+      )
     );
   });
 
@@ -47,7 +50,9 @@ describe("context tests", () => {
       });
     };
     expect(throws).toThrow(
-      "A step can not be run inside another step. Tried to run 'inner sleep' inside 'outer step'"
+      new QstashWorkflowError(
+        "A step can not be run inside another step. Tried to run 'inner sleep' inside 'outer step'"
+      )
     );
   });
 
@@ -67,7 +72,9 @@ describe("context tests", () => {
       });
     };
     expect(throws).toThrow(
-      "A step can not be run inside another step. Tried to run 'inner sleepUntil' inside 'outer step'"
+      new QstashWorkflowError(
+        "A step can not be run inside another step. Tried to run 'inner sleepUntil' inside 'outer step'"
+      )
     );
   });
 
@@ -87,7 +94,9 @@ describe("context tests", () => {
       });
     };
     expect(throws).toThrow(
-      "A step can not be run inside another step. Tried to run 'inner call' inside 'outer step'"
+      new QstashWorkflowError(
+        "A step can not be run inside another step. Tried to run 'inner call' inside 'outer step'"
+      )
     );
   });
 

--- a/src/client/workflow/context.test.ts
+++ b/src/client/workflow/context.test.ts
@@ -130,7 +130,7 @@ describe("context tests", () => {
         token,
         body: [
           {
-            body: '{"stepId":1,"stepName":"my-step","stepType":"Run","out":"my-result","concurrent":1,"targetStep":0}',
+            body: '{"stepId":1,"stepName":"my-step","stepType":"Run","out":"my-result","concurrent":1}',
             destination: WORKFLOW_ENDPOINT,
             headers: {
               "content-type": "application/json",

--- a/src/client/workflow/context.ts
+++ b/src/client/workflow/context.ts
@@ -1,9 +1,14 @@
+import type { Err, Ok } from "neverthrow";
+import { err, ok } from "neverthrow";
+import type { RouteFunction } from "./types";
 import { type AsyncStepFunction, type Step } from "./types";
-import type { Client } from "../client";
+import { Client } from "../client";
 import { AutoExecutor } from "./auto-executor";
+import type { BaseLazyStep } from "./steps";
 import { LazyCallStep, LazyFunctionStep, LazySleepStep, LazySleepUntilStep } from "./steps";
 import type { HTTPMethods } from "../types";
 import type { WorkflowLogger } from "./logger";
+import { QstashWorkflowAbort } from "../error";
 
 export class WorkflowContext<TInitialPayload = unknown> {
   protected readonly executor: AutoExecutor;
@@ -15,31 +20,35 @@ export class WorkflowContext<TInitialPayload = unknown> {
   public readonly url: string;
   public readonly requestPayload: TInitialPayload;
   public readonly headers: Headers;
+  public readonly rawInitialPayload: string;
 
   constructor({
     client,
     workflowRunId,
-    initialPayload,
     headers,
     steps,
     url,
     debug,
+    initialPayload,
+    rawInitialPayload,
   }: {
     client: Client;
     workflowRunId: string;
-    initialPayload: TInitialPayload;
     headers: Headers;
     steps: Step[];
     url: string;
     debug?: WorkflowLogger;
+    initialPayload: TInitialPayload;
+    rawInitialPayload?: string; // optional for tests
   }) {
     this.client = client;
     this.workflowRunId = workflowRunId;
     this.steps = steps;
     this.url = url;
-    this.requestPayload = initialPayload;
     this.headers = headers;
     this.nonPlanStepCount = this.steps.filter((step) => !step.targetStep).length;
+    this.requestPayload = initialPayload;
+    this.rawInitialPayload = rawInitialPayload ?? JSON.stringify(this.requestPayload);
 
     this.executor = new AutoExecutor(this, debug);
   }
@@ -76,7 +85,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     stepFunction: AsyncStepFunction<TResult>
   ): Promise<TResult> {
     const wrappedStepFunction = async () => this.executor.wrapStep(stepName, stepFunction);
-    return this.executor.addStep<TResult>(new LazyFunctionStep(stepName, wrappedStepFunction));
+    return this.addStep<TResult>(new LazyFunctionStep(stepName, wrappedStepFunction));
   }
 
   /**
@@ -87,7 +96,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
    * @returns
    */
   public async sleep(stepName: string, duration: number): Promise<void> {
-    await this.executor.addStep(new LazySleepStep(stepName, duration));
+    await this.addStep(new LazySleepStep(stepName, duration));
   }
 
   /**
@@ -108,7 +117,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
       // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       time = Math.round(datetime.getTime() / 1000);
     }
-    await this.executor.addStep(new LazySleepUntilStep(stepName, time));
+    await this.addStep(new LazySleepUntilStep(stepName, time));
   }
 
   public async call<TResult = unknown, TBody = unknown>(
@@ -118,8 +127,95 @@ export class WorkflowContext<TInitialPayload = unknown> {
     body?: TBody,
     headers?: Record<string, string>
   ) {
-    return await this.executor.addStep(
+    return await this.addStep(
       new LazyCallStep<TResult>(stepName, url, method, body, headers ?? {})
     );
+  }
+
+  /**
+   * Adds steps to the executor. Needed so that it can be overwritten in
+   * DisabledWorkflowContext.
+   */
+  protected async addStep<TResult = unknown>(step: BaseLazyStep<TResult>) {
+    return await this.executor.addStep(step);
+  }
+}
+
+/**
+ * Workflow context which throws QstashWorkflowAbort before running the steps.
+ *
+ * Used for making a dry run before running any steps to check authentication.
+ *
+ * Consider an endpoint like this:
+ * ```ts
+ * export const POST = serve({
+ *   routeFunction: context => {
+ *     if (context.headers.get("authentication") !== "Bearer secretPassword") {
+ *       console.error("Authentication failed.");
+ *       return;
+ *     }
+ *
+ *     // ...
+ *   }
+ * })
+ * ```
+ *
+ * the serve method will first call the routeFunction with an DisabledWorkflowContext.
+ * Here is the action we take in different cases
+ * - "step-found": we will run the workflow related sections of `serve`.
+ * - "run-ended": simply return success and end the workflow
+ * - error: returns 500.
+ */
+export class DisabledWorkflowContext<
+  TInitialPayload = unknown,
+> extends WorkflowContext<TInitialPayload> {
+  private static readonly disabledMessage = "disabled-qstash-worklfow-run";
+
+  /**
+   * overwrite the WorkflowContext.addStep method to always raise QstashWorkflowAbort
+   * error in order to stop the execution whenever we encounter a step.
+   *
+   * @param _step
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  protected async addStep<TResult = unknown>(_step: BaseLazyStep<TResult>): Promise<TResult> {
+    throw new QstashWorkflowAbort(DisabledWorkflowContext.disabledMessage);
+  }
+
+  /**
+   * copies the passed context to create a DisabledWorkflowContext. Then, runs the
+   * route function with the new context.
+   *
+   * - returns "run-ended" if there are no steps found or
+   *      if the auth failed and user called `return`
+   * - returns "step-found" if DisabledWorkflowContext.addStep is called.
+   * - if there is another error, returns the error.
+   *
+   * @param routeFunction
+   */
+  public static async tryAuthentication<TInitialPayload = unknown>(
+    routeFunction: RouteFunction<TInitialPayload>,
+    context: WorkflowContext<TInitialPayload>
+  ): Promise<Ok<"step-found" | "run-ended", never> | Err<never, Error>> {
+    const disabledContext = new DisabledWorkflowContext({
+      client: new Client({ baseUrl: "disabled-client", token: "disabled-client" }),
+      workflowRunId: context.workflowRunId,
+      headers: context.headers,
+      steps: context.steps,
+      url: context.url,
+      initialPayload: context.requestPayload,
+      rawInitialPayload: context.rawInitialPayload,
+    });
+
+    try {
+      await routeFunction(disabledContext);
+    } catch (error) {
+      if (error instanceof QstashWorkflowAbort && error.stepName === this.disabledMessage) {
+        return ok("step-found");
+      }
+      return err(error as Error);
+    }
+
+    return ok("run-ended");
   }
 }

--- a/src/client/workflow/context.ts
+++ b/src/client/workflow/context.ts
@@ -17,6 +17,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
   public readonly workflowRunId: string;
   public readonly steps: Step[];
   public readonly url: string;
+  public readonly failureUrl: string | false;
   public readonly requestPayload: TInitialPayload;
   public readonly headers: Headers;
   public readonly rawInitialPayload: string;
@@ -27,6 +28,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     headers,
     steps,
     url,
+    failureUrl = false,
     debug,
     initialPayload,
     rawInitialPayload,
@@ -36,6 +38,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     headers: Headers;
     steps: Step[];
     url: string;
+    failureUrl?: string | false;
     debug?: WorkflowLogger;
     initialPayload: TInitialPayload;
     rawInitialPayload?: string; // optional for tests
@@ -44,6 +47,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     this.workflowRunId = workflowRunId;
     this.steps = steps;
     this.url = url;
+    this.failureUrl = failureUrl;
     this.headers = headers;
     this.requestPayload = initialPayload;
     this.rawInitialPayload = rawInitialPayload ?? JSON.stringify(this.requestPayload);
@@ -201,6 +205,7 @@ export class DisabledWorkflowContext<
       headers: context.headers,
       steps: context.steps,
       url: context.url,
+      failureUrl: context.failureUrl,
       initialPayload: context.requestPayload,
       rawInitialPayload: context.rawInitialPayload,
     });

--- a/src/client/workflow/context.ts
+++ b/src/client/workflow/context.ts
@@ -17,7 +17,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
   public readonly workflowRunId: string;
   public readonly steps: Step[];
   public readonly url: string;
-  public readonly failureUrl: string | false;
+  public readonly failureUrl?: string;
   public readonly requestPayload: TInitialPayload;
   public readonly headers: Headers;
   public readonly rawInitialPayload: string;
@@ -28,7 +28,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     headers,
     steps,
     url,
-    failureUrl = false,
+    failureUrl,
     debug,
     initialPayload,
     rawInitialPayload,
@@ -38,7 +38,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     headers: Headers;
     steps: Step[];
     url: string;
-    failureUrl?: string | false;
+    failureUrl?: string;
     debug?: WorkflowLogger;
     initialPayload: TInitialPayload;
     rawInitialPayload?: string; // optional for tests

--- a/src/client/workflow/context.ts
+++ b/src/client/workflow/context.ts
@@ -16,7 +16,6 @@ export class WorkflowContext<TInitialPayload = unknown> {
   public readonly client: Client;
   public readonly workflowRunId: string;
   public readonly steps: Step[];
-  public readonly nonPlanStepCount: number;
   public readonly url: string;
   public readonly requestPayload: TInitialPayload;
   public readonly headers: Headers;
@@ -46,7 +45,6 @@ export class WorkflowContext<TInitialPayload = unknown> {
     this.steps = steps;
     this.url = url;
     this.headers = headers;
-    this.nonPlanStepCount = this.steps.filter((step) => !step.targetStep).length;
     this.requestPayload = initialPayload;
     this.rawInitialPayload = rawInitialPayload ?? JSON.stringify(this.requestPayload);
 

--- a/src/client/workflow/integration.test.ts
+++ b/src/client/workflow/integration.test.ts
@@ -326,7 +326,7 @@ describe.skip("live serve tests", () => {
       const finishState = new FinishState();
       await testEndpoint({
         finalCount: 1,
-        waitFor: 2000,
+        waitFor: 4500,
         initialPayload: "my-payload",
         finishState,
         routeFunction: async (context) => {
@@ -340,7 +340,7 @@ describe.skip("live serve tests", () => {
       });
     },
     {
-      timeout: 3000,
+      timeout: 5000,
     }
   );
 

--- a/src/client/workflow/integration.test.ts
+++ b/src/client/workflow/integration.test.ts
@@ -53,7 +53,7 @@ import { serve } from "bun";
 import { serve as workflowServe } from "./serve";
 import { expect, test, describe } from "bun:test";
 import { Client } from "../client";
-import type { WorkflowContext } from "./context";
+import type { RouteFunction } from "./types";
 
 const WORKFLOW_PORT = "3000";
 const THIRD_PARTY_PORT = "3001";
@@ -110,7 +110,7 @@ const testEndpoint = async <TInitialPayload = unknown>({
   finalCount: number;
   waitFor: number;
   initialPayload: TInitialPayload;
-  routeFunction: (context: WorkflowContext<TInitialPayload>) => Promise<void>;
+  routeFunction: RouteFunction<TInitialPayload>;
   finishState: FinishState;
 }) => {
   let counter = 0;
@@ -317,6 +317,30 @@ describe.skip("live serve tests", () => {
     },
     {
       timeout: 12_000,
+    }
+  );
+
+  test(
+    "auth endpoint - failed authentication",
+    async () => {
+      const finishState = new FinishState();
+      await testEndpoint({
+        finalCount: 1,
+        waitFor: 2000,
+        initialPayload: "my-payload",
+        finishState,
+        routeFunction: async (context) => {
+          if (context.headers.get("authentication") !== "Bearer aDifferentPassword") {
+            console.error("Authentication failed.");
+            finishState.finish();
+            return;
+          }
+          throw new Error("shouldn't be here.");
+        },
+      });
+    },
+    {
+      timeout: 3000,
     }
   );
 

--- a/src/client/workflow/logger.ts
+++ b/src/client/workflow/logger.ts
@@ -65,7 +65,7 @@ export class WorkflowLogger {
     return LOG_LEVELS.indexOf(level) >= LOG_LEVELS.indexOf(this.options.logLevel);
   }
 
-  public static getLogger(verbose: boolean | WorkflowLogger) {
+  public static getLogger(verbose?: boolean | WorkflowLogger) {
     if (typeof verbose === "object") {
       return verbose;
     } else {

--- a/src/client/workflow/receiver.test.ts
+++ b/src/client/workflow/receiver.test.ts
@@ -309,7 +309,6 @@ describe("receiver", () => {
             stepType: "Run",
             out: atob(randomBody),
             concurrent: 1,
-            targetStep: 0,
           },
         },
       });
@@ -326,7 +325,6 @@ describe("receiver", () => {
       stepType: "Run",
       out: "result",
       concurrent: 1,
-      targetStep: 0,
     };
 
     test("should block request without signature", async () => {

--- a/src/client/workflow/receiver.test.ts
+++ b/src/client/workflow/receiver.test.ts
@@ -232,10 +232,7 @@ describe("receiver", () => {
       await mockQstashServer({
         // eslint-disable-next-line @typescript-eslint/require-await
         execute: async () => {
-          expect(throws).toThrow(
-            "Error when handling call return (isCallReturn=true): QstashWorkflowError: " +
-              "`Upstash-Signature` header is not a string"
-          );
+          expect(throws).toThrow("`Upstash-Signature` header is not a string");
         },
         responseFields: { body: "msgId", status: 200 },
         receivesRequest: false,
@@ -265,9 +262,7 @@ describe("receiver", () => {
       await mockQstashServer({
         // eslint-disable-next-line @typescript-eslint/require-await
         execute: async () => {
-          expect(throws).toThrow(
-            "Error when handling call return (isCallReturn=true): SignatureError: Invalid Compact JWS"
-          );
+          expect(throws).toThrow("Invalid Compact JWS");
         },
         responseFields: { body: "msgId", status: 200 },
         receivesRequest: false,

--- a/src/client/workflow/serve.test.ts
+++ b/src/client/workflow/serve.test.ts
@@ -86,7 +86,6 @@ describe("serve", () => {
         stepType: "Run",
         out: `processed '${initialPayload}'`,
         concurrent: 1,
-        targetStep: 0,
       },
       {
         stepId: 2,
@@ -94,7 +93,6 @@ describe("serve", () => {
         stepType: "Run",
         out: `processed 'processed '${initialPayload}''`,
         concurrent: 1,
-        targetStep: 0,
       },
     ];
 
@@ -165,7 +163,7 @@ describe("serve", () => {
     });
   });
 
-  test.only("should return 500 on error during step execution", async () => {
+  test("should return 500 on error during step execution", async () => {
     const endpoint = serve({
       routeFunction: async (context) => {
         await context.run("wrong step", async () => {
@@ -216,9 +214,9 @@ describe("serve", () => {
     test("should return without doing anything when the last step is duplicate", async () => {
       // prettier-ignore
       const stepsWithDuplicate: Step[] = [
-        {stepId: 1, stepName: "step 1", stepType: "Run", out: "result 1", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "step 2", stepType: "Run", out: "result 2", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "step 2", stepType: "Run", out: "result 2", concurrent: 1, targetStep: 0}, // duplicate
+        {stepId: 1, stepName: "step 1", stepType: "Run", out: "result 1", concurrent: 1},
+        {stepId: 2, stepName: "step 2", stepType: "Run", out: "result 2", concurrent: 1},
+        {stepId: 2, stepName: "step 2", stepType: "Run", out: "result 2", concurrent: 1}, // duplicate
       ]
       const request = getRequest(WORKFLOW_ENDPOINT, "wfr-foo", "my-payload", stepsWithDuplicate);
       let called = false;
@@ -238,9 +236,9 @@ describe("serve", () => {
     test("should remove duplicate middle step and continue executing", async () => {
       // prettier-ignore
       const stepsWithDuplicate: Step[] = [
-        {stepId: 1, stepName: "step 1", stepType: "Run", out: "result 1", concurrent: 1, targetStep: 0},
-        {stepId: 1, stepName: "step 1", stepType: "Run", out: "result 1", concurrent: 1, targetStep: 0}, // duplicate
-        {stepId: 2, stepName: "step 2", stepType: "Run", out: "result 2", concurrent: 1, targetStep: 0}, 
+        {stepId: 1, stepName: "step 1", stepType: "Run", out: "result 1", concurrent: 1},
+        {stepId: 1, stepName: "step 1", stepType: "Run", out: "result 1", concurrent: 1}, // duplicate
+        {stepId: 2, stepName: "step 2", stepType: "Run", out: "result 2", concurrent: 1}, 
       ]
       const request = getRequest(WORKFLOW_ENDPOINT, "wfr-foo", "my-payload", stepsWithDuplicate);
       let called = false;
@@ -267,7 +265,7 @@ describe("serve", () => {
                 "upstash-workflow-runid": "wfr-foo",
                 "upstash-workflow-url": WORKFLOW_ENDPOINT,
               },
-              body: '{"stepId":3,"stepName":"step 3","stepType":"Run","out":"combined results: result 1,result 2","concurrent":1,"targetStep":0}',
+              body: '{"stepId":3,"stepName":"step 3","stepType":"Run","out":"combined results: result 1,result 2","concurrent":1}',
             },
           ],
         },

--- a/src/client/workflow/serve.test.ts
+++ b/src/client/workflow/serve.test.ts
@@ -33,7 +33,7 @@ describe("serve", () => {
       options: {
         client,
         verbose: true,
-        receiver: false,
+        receiver: undefined,
       },
     });
 
@@ -75,7 +75,7 @@ describe("serve", () => {
       options: {
         client,
         verbose: true,
-        receiver: false,
+        receiver: undefined,
       },
     });
 
@@ -173,7 +173,7 @@ describe("serve", () => {
       },
       options: {
         client,
-        receiver: false,
+        receiver: undefined,
       },
     });
 
@@ -201,7 +201,7 @@ describe("serve", () => {
       },
       options: {
         client,
-        receiver: false,
+        receiver: undefined,
       },
     });
 
@@ -239,7 +239,7 @@ describe("serve", () => {
       },
       options: {
         client,
-        receiver: false,
+        receiver: undefined,
       },
     });
 
@@ -326,7 +326,7 @@ describe("serve", () => {
         routeFunction,
         options: {
           client,
-          receiver: false,
+          receiver: undefined,
         },
       });
       let called = false;
@@ -367,7 +367,7 @@ describe("serve", () => {
         routeFunction,
         options: {
           client,
-          receiver: false,
+          receiver: undefined,
           failureUrl: myFailureEndpoint,
         },
       });
@@ -419,7 +419,7 @@ describe("serve", () => {
         routeFunction,
         options: {
           client,
-          receiver: false,
+          receiver: undefined,
           failureFunction: myFailureFunction,
         },
       });

--- a/src/client/workflow/steps.test.ts
+++ b/src/client/workflow/steps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
 import { describe, test, expect } from "bun:test";
 import { LazyCallStep, LazyFunctionStep, LazySleepStep, LazySleepUntilStep } from "./steps";
 import { nanoid } from "nanoid";
@@ -37,13 +38,11 @@ describe("test steps", () => {
         stepName,
         stepType: "Run",
         out: result,
-        concurrent: 1,
+        concurrent: 9,
         targetStep: 0,
       };
 
-      // _singleStep has no affect:
-      expect(await step.getResultStep(stepId, false)).toEqual(resultStep);
-      expect(await step.getResultStep(stepId, true)).toEqual(resultStep);
+      expect(await step.getResultStep(9, stepId)).toEqual(resultStep);
     });
   });
 
@@ -67,23 +66,12 @@ describe("test steps", () => {
     });
 
     test("should create result step", async () => {
-      // if singleStep=false, then we are running parallel and the
-      // sleep was applied in the sleep step.
-      expect(await step.getResultStep(stepId, false)).toEqual({
-        stepId,
-        stepName,
-        stepType: "SleepFor",
-        concurrent: 1,
-        targetStep: 0,
-      });
-
-      // if singleStep=true, then we should sleep
-      expect(await step.getResultStep(stepId, true)).toEqual({
+      expect(await step.getResultStep(6, stepId)).toEqual({
         stepId,
         stepName,
         stepType: "SleepFor",
         sleepFor: sleepAmount, // adding sleepFor
-        concurrent: 1,
+        concurrent: 6,
         targetStep: 0,
       });
     });
@@ -109,23 +97,12 @@ describe("test steps", () => {
     });
 
     test("should create result step", async () => {
-      // if singleStep=false, then we are running parallel and the
-      // sleep was applied in the sleep step.
-      expect(await step.getResultStep(stepId, false)).toEqual({
+      expect(await step.getResultStep(4, stepId)).toEqual({
         stepId,
         stepName,
         stepType: "SleepUntil",
-        concurrent: 1,
-        targetStep: 0,
-      });
-
-      // if singleStep=true, then we should sleep
-      expect(await step.getResultStep(stepId, true)).toEqual({
-        stepId,
-        stepName,
-        stepType: "SleepUntil",
-        sleepUntil: sleepUntilTime, // adding sleepFor
-        concurrent: 1,
+        sleepUntil: sleepUntilTime, // adding sleepUntil
+        concurrent: 4,
         targetStep: 0,
       });
     });
@@ -157,12 +134,12 @@ describe("test steps", () => {
     });
 
     test("should create result step", async () => {
-      expect(await step.getResultStep(stepId)).toEqual({
+      expect(await step.getResultStep(4, stepId)).toEqual({
         callBody,
         callHeaders,
         callMethod,
         callUrl,
-        concurrent: 1,
+        concurrent: 4,
         stepId,
         stepName,
         stepType: "Call",

--- a/src/client/workflow/steps.test.ts
+++ b/src/client/workflow/steps.test.ts
@@ -39,7 +39,6 @@ describe("test steps", () => {
         stepType: "Run",
         out: result,
         concurrent: 9,
-        targetStep: 0,
       };
 
       expect(await step.getResultStep(9, stepId)).toEqual(resultStep);
@@ -72,7 +71,6 @@ describe("test steps", () => {
         stepType: "SleepFor",
         sleepFor: sleepAmount, // adding sleepFor
         concurrent: 6,
-        targetStep: 0,
       });
     });
   });
@@ -103,7 +101,6 @@ describe("test steps", () => {
         stepType: "SleepUntil",
         sleepUntil: sleepUntilTime, // adding sleepUntil
         concurrent: 4,
-        targetStep: 0,
       });
     });
   });
@@ -143,7 +140,6 @@ describe("test steps", () => {
         stepId,
         stepName,
         stepType: "Call",
-        targetStep: 0,
       });
     });
   });

--- a/src/client/workflow/steps.ts
+++ b/src/client/workflow/steps.ts
@@ -68,7 +68,6 @@ export class LazyFunctionStep<TResult = unknown> extends BaseLazyStep<TResult> {
       stepType: this.stepType,
       out: result,
       concurrent,
-      targetStep: 0,
     };
   }
 }
@@ -105,7 +104,6 @@ export class LazySleepStep extends BaseLazyStep {
       stepType: this.stepType,
       sleepFor: this.sleep,
       concurrent,
-      targetStep: 0,
     });
   }
 }
@@ -142,7 +140,6 @@ export class LazySleepUntilStep extends BaseLazyStep {
       stepType: this.stepType,
       sleepUntil: this.sleepUntil,
       concurrent,
-      targetStep: 0,
     });
   }
 }
@@ -186,7 +183,6 @@ export class LazyCallStep<TResult = unknown, TBody = unknown> extends BaseLazySt
       stepName: this.stepName,
       stepType: this.stepType,
       concurrent,
-      targetStep: 0,
       callUrl: this.url,
       callMethod: this.method,
       callBody: this.body,

--- a/src/client/workflow/steps.ts
+++ b/src/client/workflow/steps.ts
@@ -29,9 +29,10 @@ export abstract class BaseLazyStep<TResult = unknown> {
    * result step to submit after the step executes. Used in single step executions
    * and when a plan step executes in parallel executions (parallel call state `partial`).
    *
+   * @param concurrent
    * @param stepId
    */
-  public abstract getResultStep(stepId: number, singleStep: boolean): Promise<Step<TResult>>;
+  public abstract getResultStep(concurrent: number, stepId: number): Promise<Step<TResult>>;
 }
 
 /**
@@ -58,7 +59,7 @@ export class LazyFunctionStep<TResult = unknown> extends BaseLazyStep<TResult> {
     }
   }
 
-  public async getResultStep(stepId: number, _singleStep: boolean): Promise<Step<TResult>> {
+  public async getResultStep(concurrent: number, stepId: number): Promise<Step<TResult>> {
     const result = await this.stepFunction();
 
     return {
@@ -66,7 +67,7 @@ export class LazyFunctionStep<TResult = unknown> extends BaseLazyStep<TResult> {
       stepName: this.stepName,
       stepType: this.stepType,
       out: result,
-      concurrent: 1,
+      concurrent,
       targetStep: 0,
     };
   }
@@ -97,15 +98,13 @@ export class LazySleepStep extends BaseLazyStep {
     }
   }
 
-  public async getResultStep(stepId: number, singleStep: boolean): Promise<Step> {
+  public async getResultStep(concurrent: number, stepId: number): Promise<Step> {
     return await Promise.resolve({
       stepId,
       stepName: this.stepName,
       stepType: this.stepType,
-      // apply sleepFor if the step is running by itself. If it's running parallel,
-      // the sleepFor is already applied in the plan step
-      sleepFor: singleStep ? this.sleep : undefined,
-      concurrent: 1,
+      sleepFor: this.sleep,
+      concurrent,
       targetStep: 0,
     });
   }
@@ -136,15 +135,13 @@ export class LazySleepUntilStep extends BaseLazyStep {
     }
   }
 
-  public async getResultStep(stepId: number, singleStep: boolean): Promise<Step> {
+  public async getResultStep(concurrent: number, stepId: number): Promise<Step> {
     return await Promise.resolve({
       stepId,
       stepName: this.stepName,
       stepType: this.stepType,
-      // apply sleepUntil if the step is running by itself. If it's running parallel,
-      // the sleepUntil is already applied in the plan step
-      sleepUntil: singleStep ? this.sleepUntil : undefined,
-      concurrent: 1,
+      sleepUntil: this.sleepUntil,
+      concurrent,
       targetStep: 0,
     });
   }
@@ -183,12 +180,12 @@ export class LazyCallStep<TResult = unknown, TBody = unknown> extends BaseLazySt
     }
   }
 
-  public async getResultStep(stepId: number): Promise<Step<TResult>> {
+  public async getResultStep(concurrent: number, stepId: number): Promise<Step<TResult>> {
     return await Promise.resolve({
       stepId,
       stepName: this.stepName,
       stepType: this.stepType,
-      concurrent: 1,
+      concurrent,
       targetStep: 0,
       callUrl: this.url,
       callMethod: this.method,

--- a/src/client/workflow/types.ts
+++ b/src/client/workflow/types.ts
@@ -79,8 +79,12 @@ export type StepFunction<TResult> = AsyncStepFunction<TResult> | SyncStepFunctio
 
 export type ParallelCallState = "first" | "partial" | "discard" | "last";
 
+export type RouteFunction<TInitialPayload> = (
+  context: WorkflowContext<TInitialPayload>
+) => Promise<void>;
+
 export type WorkflowServeParameters<TInitialPayload, TResponse = Response> = {
-  routeFunction: (context: WorkflowContext<TInitialPayload>) => Promise<void>;
+  routeFunction: RouteFunction<TInitialPayload>;
   options?: WorkflowServeOptions<TResponse, TInitialPayload>;
 };
 
@@ -108,7 +112,7 @@ export type WorkflowServeParametersExtended<TInitialPayload = unknown, TResponse
 export type InitialPayloadParser<TInitialPayload = unknown> = (
   initialPayload: string
 ) => TInitialPayload;
-
+export type FinishCondition = "success" | "duplicate-step" | "fromCallback" | "auth-fail";
 export type WorkflowServeOptions<TResponse = Response, TInitialPayload = unknown> = {
   /**
    * QStash client
@@ -120,7 +124,7 @@ export type WorkflowServeOptions<TResponse = Response, TInitialPayload = unknown
    * @param workflowRunId
    * @returns response
    */
-  onStepFinish?: (workflowRunId: string) => TResponse;
+  onStepFinish?: (workflowRunId: string, finishCondition: FinishCondition) => TResponse;
   /**
    * Function to parse the initial payload passed by the user
    */

--- a/src/client/workflow/types.ts
+++ b/src/client/workflow/types.ts
@@ -63,13 +63,14 @@ export type Step<TResult = unknown, TBody = unknown> = {
    * Set to 0 if the step is not a plan step (of a parallel run). Otherwise,
    * set to the target step.
    */
-  targetStep: number;
+  targetStep?: number;
 } & (ThirdPartyCallFields<TBody> | { [P in keyof ThirdPartyCallFields]?: never });
 
+export type CallType = "step" | "toCallback" | "fromCallback";
 export type RawStep = {
   messageId: string;
   body: string; // body is a base64 encoded step or payload
-  callType: "step" | "toCallback" | "fromCallback";
+  callType: CallType;
 };
 
 export type SyncStepFunction<TResult> = () => TResult;

--- a/src/client/workflow/types.ts
+++ b/src/client/workflow/types.ts
@@ -134,27 +134,36 @@ export type WorkflowServeOptions<TResponse = Response, TInitialPayload = unknown
   /**
    * Verbose mode
    *
-   * Disabled if set to false. If set to true, a logger is created automatically.
+   * Disabled if not set. If set to true, a logger is created automatically.
    *
    * Alternatively, a WorkflowLogger can be passed.
-   *
-   * Disabled by default
    */
-  verbose?: WorkflowLogger | boolean;
+  verbose?: WorkflowLogger | true;
   /**
-   * Receiver to verify requests coming from QStash
+   * Receiver to verify *all* requests by checking if they come from QStash
    *
-   * All requests except the first invocation are verified.
-   *
-   * Enabled by default. A receiver is created from the env variables
-   * QSTASH_CURRENT_SIGNING_KEY and QSTASH_NEXT_SIGNING_KEY.
+   * By default, a receiver is created from the env variables
+   * QSTASH_CURRENT_SIGNING_KEY and QSTASH_NEXT_SIGNING_KEY if they are set.
    */
-  receiver?: Receiver | false;
+  receiver?: Receiver;
   /**
-   *
+   * Url to call if QStash retries are exhausted while executing the workflow
    */
-  failureUrl?: string | false;
-  failureFunction?:
-    | ((status: number, header: Record<string, string>, body: string) => Promise<void>)
-    | false;
+  failureUrl?: string;
+  /**
+   * Failure function called when QStash retries are exhausted while executing
+   * the workflow. Will overwrite `failureUrl` parameter with the workflow
+   * endpoint if passed.
+   *
+   * @param status failure status
+   * @param header headers of the request which failed
+   * @param body body which contains the error message
+   * @returns void
+   */
+  failureFunction?: (status: number, header: Record<string, string>, body: string) => Promise<void>;
 };
+
+/**
+ * Makes all fields except the ones selected required
+ */
+export type RequiredExceptFields<T, K extends keyof T> = Omit<Required<T>, K> & Partial<Pick<T, K>>;

--- a/src/client/workflow/workflow-parser.test.ts
+++ b/src/client/workflow/workflow-parser.test.ts
@@ -90,11 +90,11 @@ describe("Workflow Parser", () => {
       const request = new Request(WORKFLOW_ENDPOINT, {
         body: rawPayload,
       });
-      const { initialPayload, steps, isLastDuplicate } = await parseRequest(request, true);
+      const { rawInitialPayload, steps, isLastDuplicate } = await parseRequest(request, true);
 
       // payload isn't parsed
-      expect(typeof initialPayload).toBe("string");
-      expect(initialPayload).toBe(rawPayload);
+      expect(typeof rawInitialPayload).toBe("string");
+      expect(rawInitialPayload).toBe(rawPayload);
       // steps are empty:
       expect(steps).toEqual([]);
       expect(isLastDuplicate).toBeFalse();
@@ -129,11 +129,11 @@ describe("Workflow Parser", () => {
       ];
 
       const request = getRequest(WORKFLOW_ENDPOINT, "wfr-id", requestInitialPayload, resultSteps);
-      const { initialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
+      const { rawInitialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
 
       // payload is not parsed
-      expect(typeof initialPayload).toEqual("string");
-      expect(initialPayload).toEqual(JSON.stringify(requestInitialPayload));
+      expect(typeof rawInitialPayload).toEqual("string");
+      expect(rawInitialPayload).toEqual(JSON.stringify(requestInitialPayload));
       expect(isLastDuplicate).toBeFalse();
 
       // steps
@@ -143,7 +143,7 @@ describe("Workflow Parser", () => {
           stepId: 0,
           stepName: "init",
           stepType: "Initial",
-          out: initialPayload,
+          out: rawInitialPayload,
           concurrent: 1,
         },
         ...resultSteps,
@@ -195,9 +195,9 @@ describe("Workflow Parser", () => {
       ];
 
       const request = new Request(WORKFLOW_ENDPOINT, { body: JSON.stringify(payload) });
-      const { initialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
+      const { rawInitialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
 
-      expect(initialPayload).toBe(reqiestInitialPayload);
+      expect(rawInitialPayload).toBe(reqiestInitialPayload);
 
       expect(steps.length).toBe(2);
       expect(steps[0].stepId).toBe(0);
@@ -225,9 +225,9 @@ describe("Workflow Parser", () => {
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
-      const { initialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
+      const { rawInitialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
 
-      expect(initialPayload).toBe(requestPayload);
+      expect(rawInitialPayload).toBe(requestPayload);
       expect(isLastDuplicate).toBeFalse();
 
       // prettier-ignore
@@ -248,9 +248,9 @@ describe("Workflow Parser", () => {
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
-      const { initialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
+      const { rawInitialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
 
-      expect(initialPayload).toBe(requestPayload);
+      expect(rawInitialPayload).toBe(requestPayload);
       expect(isLastDuplicate).toBeTrue();
 
       // prettier-ignore
@@ -276,9 +276,9 @@ describe("Workflow Parser", () => {
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
-      const { initialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
+      const { rawInitialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
 
-      expect(initialPayload).toBe(requestPayload);
+      expect(rawInitialPayload).toBe(requestPayload);
       expect(isLastDuplicate).toBeFalse();
 
       // prettier-ignore
@@ -306,9 +306,9 @@ describe("Workflow Parser", () => {
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
-      const { initialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
+      const { rawInitialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
 
-      expect(initialPayload).toBe(requestPayload);
+      expect(rawInitialPayload).toBe(requestPayload);
       expect(isLastDuplicate).toBeTrue();
 
       // prettier-ignore
@@ -337,9 +337,9 @@ describe("Workflow Parser", () => {
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
-      const { initialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
+      const { rawInitialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
 
-      expect(initialPayload).toBe(requestPayload);
+      expect(rawInitialPayload).toBe(requestPayload);
       expect(isLastDuplicate).toBeTrue();
 
       // prettier-ignore
@@ -364,9 +364,9 @@ describe("Workflow Parser", () => {
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
-      const { initialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
+      const { rawInitialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
 
-      expect(initialPayload).toBe(requestPayload);
+      expect(rawInitialPayload).toBe(requestPayload);
       expect(isLastDuplicate).toBeTrue();
 
       // prettier-ignore
@@ -386,9 +386,9 @@ describe("Workflow Parser", () => {
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
-      const { initialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
+      const { rawInitialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
 
-      expect(initialPayload).toBe(requestPayload);
+      expect(rawInitialPayload).toBe(requestPayload);
       expect(isLastDuplicate).toBeFalse();
 
       // prettier-ignore
@@ -420,9 +420,9 @@ describe("Workflow Parser", () => {
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
-      const { initialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
+      const { rawInitialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
 
-      expect(initialPayload).toBe(requestPayload);
+      expect(rawInitialPayload).toBe(requestPayload);
       expect(isLastDuplicate).toBeTrue();
 
       // prettier-ignore
@@ -458,9 +458,9 @@ describe("Workflow Parser", () => {
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
-      const { initialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
+      const { rawInitialPayload, steps, isLastDuplicate } = await parseRequest(request, false);
 
-      expect(initialPayload).toBe(requestPayload);
+      expect(rawInitialPayload).toBe(requestPayload);
       expect(isLastDuplicate).toBeFalse();
 
       // prettier-ignore

--- a/src/client/workflow/workflow-parser.test.ts
+++ b/src/client/workflow/workflow-parser.test.ts
@@ -9,6 +9,7 @@ import {
 import { nanoid } from "nanoid";
 import type { Step } from "./types";
 import { getRequest, WORKFLOW_ENDPOINT } from "./test-utils";
+import { QstashWorkflowError } from "../error";
 
 describe("Workflow Parser", () => {
   describe("validateRequest", () => {
@@ -47,7 +48,7 @@ describe("Workflow Parser", () => {
       });
 
       const throws = () => validateRequest(request);
-      expect(throws).toThrow("Couldn't get workflow id from header");
+      expect(throws).toThrow(new QstashWorkflowError("Couldn't get workflow id from header"));
     });
 
     test("should throw when protocol version is incompatible", () => {
@@ -60,8 +61,10 @@ describe("Workflow Parser", () => {
 
       const throws = () => validateRequest(request);
       expect(throws).toThrow(
-        `Incompatible workflow sdk protocol version.` +
-          ` Expected ${WORKFLOW_PROTOCOL_VERSION}, got ${requestProtocol} from the request.`
+        new QstashWorkflowError(
+          `Incompatible workflow sdk protocol version.` +
+            ` Expected ${WORKFLOW_PROTOCOL_VERSION}, got ${requestProtocol} from the request.`
+        )
       );
     });
 
@@ -101,7 +104,9 @@ describe("Workflow Parser", () => {
       const request = new Request(WORKFLOW_ENDPOINT);
       // isFirstInvocation = false:
       const throws = parseRequest(request, false);
-      expect(throws).rejects.toThrow("Only first call can have an empty body");
+      expect(throws).rejects.toThrow(
+        new QstashWorkflowError("Only first call can have an empty body")
+      );
     });
 
     test("should return steps and initial payload correctly", async () => {

--- a/src/client/workflow/workflow-parser.test.ts
+++ b/src/client/workflow/workflow-parser.test.ts
@@ -118,7 +118,6 @@ describe("Workflow Parser", () => {
           stepType: "Run",
           out: "first result",
           concurrent: 1,
-          targetStep: 0,
         },
         {
           stepId: 2,
@@ -126,7 +125,6 @@ describe("Workflow Parser", () => {
           stepType: "Run",
           out: "second result",
           concurrent: 1,
-          targetStep: 0,
         },
       ];
 
@@ -146,7 +144,6 @@ describe("Workflow Parser", () => {
           stepName: "init",
           stepType: "Initial",
           out: initialPayload,
-          targetStep: 0,
           concurrent: 1,
         },
         ...resultSteps,
@@ -217,15 +214,14 @@ describe("Workflow Parser", () => {
       stepType: "Initial",
       out: requestPayload,
       concurrent: 1,
-      targetStep: 0,
     };
     const workflowId = "wfr-foo";
 
     test("should ignore extra init steps", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 0, stepName: "init", stepType: "Initial", out: "duplicate-payload", concurrent: 1, targetStep: 0},
-        {stepId: 1, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
+        {stepId: 0, stepName: "init", stepType: "Initial", out: "duplicate-payload", concurrent: 1},
+        {stepId: 1, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
@@ -237,17 +233,17 @@ describe("Workflow Parser", () => {
       // prettier-ignore
       expect(steps).toEqual([
         initStep,
-        {stepId: 1, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
       ])
     });
 
     test("target step duplicated at the end", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1, targetStep: 0},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5}, // duplicate
       ]
 
@@ -260,22 +256,22 @@ describe("Workflow Parser", () => {
       // prettier-ignore
       expect(steps).toEqual([
         initStep,
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1, targetStep: 0},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
       ])
     });
 
     test("target step duplicated in the middle", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4}, // duplicate
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2, targetStep: 0},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
       ]
 
@@ -288,11 +284,11 @@ describe("Workflow Parser", () => {
       // prettier-ignore
       expect(steps).toEqual([
         initStep,
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2, targetStep: 0},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
       ])
     });
@@ -300,13 +296,13 @@ describe("Workflow Parser", () => {
     test("concurrent step result duplicated", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out: "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out: "true", concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out: "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out: "true", concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2, targetStep: 0},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2, targetStep: 0}, // duplicate
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2}, // duplicate
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
@@ -318,26 +314,26 @@ describe("Workflow Parser", () => {
       // prettier-ignore
       expect(steps).toEqual([
         initStep,
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out: "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out: "true", concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out: "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out: "true", concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2, targetStep: 0},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2},
       ])
     });
 
     test("concurrent step result duplicated with two results", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out: "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out: "true", concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out: "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out: "true", concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out: "10", concurrent: 2, targetStep: 0},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out: "10", concurrent: 2},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2, targetStep: 0},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2, targetStep: 0}, // duplicate
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2}, // duplicate
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
@@ -349,22 +345,22 @@ describe("Workflow Parser", () => {
       // prettier-ignore
       expect(steps).toEqual([
         initStep,
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out: "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out: "true", concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out: "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out: "true", concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out: "10", concurrent: 2, targetStep: 0},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out: "10", concurrent: 2},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2, targetStep: 0},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2},
       ])
     });
 
     test("result step duplicate", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0}, // duplicate
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1}, // duplicate
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
@@ -376,17 +372,17 @@ describe("Workflow Parser", () => {
       // prettier-ignore
       expect(steps).toEqual([
         initStep,
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
       ])
     });
 
     test("duplicate results in the middle", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0}, // duplicate
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1}, // duplicate
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
@@ -398,29 +394,29 @@ describe("Workflow Parser", () => {
       // prettier-ignore
       expect(steps).toEqual([
         initStep,
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
       ])
     });
 
     test("all duplicated", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1, targetStep: 0},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2, targetStep: 0},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2, targetStep: 0},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  "20", concurrent: 2, targetStep: 0},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  "20", concurrent: 2, targetStep: 0},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  "20", concurrent: 2},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  "20", concurrent: 2},
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
@@ -432,33 +428,33 @@ describe("Workflow Parser", () => {
       // prettier-ignore
       expect(steps).toEqual([
         initStep,
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2, targetStep: 0},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  "20", concurrent: 2, targetStep: 0},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  "20", concurrent: 2},
       ])
     });
 
     test("all duplicated except last", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1, targetStep: 0},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2, targetStep: 0},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2, targetStep: 0},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  "20", concurrent: 2, targetStep: 0},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  "20", concurrent: 2},
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
@@ -470,13 +466,13 @@ describe("Workflow Parser", () => {
       // prettier-ignore
       expect(steps).toEqual([
         initStep,
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1, targetStep: 0},
-        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1, targetStep: 0},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1, targetStep: 0},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2, targetStep: 0},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  "20", concurrent: 2, targetStep: 0},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  "20", concurrent: 2},
       ])
     });
   });

--- a/src/client/workflow/workflow-parser.ts
+++ b/src/client/workflow/workflow-parser.ts
@@ -51,12 +51,12 @@ const parsePayload = (rawPayload: string) => {
   const [encodedInitialPayload, ...encodedSteps] = JSON.parse(rawPayload) as RawStep[];
 
   // decode initial payload:
-  const initialPayload = decodeBase64(encodedInitialPayload.body);
+  const rawInitialPayload = decodeBase64(encodedInitialPayload.body);
   const initialStep: Step = {
     stepId: 0,
     stepName: "init",
     stepType: "Initial",
-    out: initialPayload,
+    out: rawInitialPayload,
     concurrent: 1,
   };
 
@@ -71,7 +71,7 @@ const parsePayload = (rawPayload: string) => {
   // join and deduplicate steps:
   const steps: Step[] = [initialStep, ...otherSteps];
   return {
-    initialPayload,
+    rawInitialPayload,
     steps,
   };
 };
@@ -201,7 +201,7 @@ export const parseRequest = async (
   verifier?: Receiver,
   debug?: WorkflowLogger
 ): Promise<{
-  initialPayload: string;
+  rawInitialPayload: string;
   steps: Step[];
   isLastDuplicate: boolean;
 }> => {
@@ -212,7 +212,7 @@ export const parseRequest = async (
   if (isFirstInvocation) {
     // if first invocation, return and `serve` will handle publishing the JSON to QStash
     return {
-      initialPayload: payload ?? "",
+      rawInitialPayload: payload ?? "",
       steps: [],
       isLastDuplicate: false,
     };
@@ -221,12 +221,12 @@ export const parseRequest = async (
     if (!payload) {
       throw new QstashWorkflowError("Only first call can have an empty body");
     }
-    const { initialPayload, steps } = parsePayload(payload);
+    const { rawInitialPayload, steps } = parsePayload(payload);
     const isLastDuplicate = await checkIfLastOneIsDuplicate(steps, debug);
     const deduplicatedSteps = deduplicateSteps(steps);
 
     return {
-      initialPayload,
+      rawInitialPayload,
       steps: deduplicatedSteps,
       isLastDuplicate,
     };

--- a/src/client/workflow/workflow-parser.ts
+++ b/src/client/workflow/workflow-parser.ts
@@ -58,7 +58,6 @@ const parsePayload = (rawPayload: string) => {
     stepType: "Initial",
     out: initialPayload,
     concurrent: 1,
-    targetStep: 0,
   };
 
   // remove "toCallback" and "fromCallback" steps:
@@ -96,9 +95,9 @@ const deduplicateSteps = (steps: Step[]): Step[] => {
   for (const step of steps) {
     if (step.stepId === 0) {
       // Step is a plan step
-      if (!targetStepIds.includes(step.targetStep)) {
+      if (!targetStepIds.includes(step.targetStep ?? 0)) {
         deduplicatedSteps.push(step);
-        targetStepIds.push(step.targetStep);
+        targetStepIds.push(step.targetStep ?? 0);
       }
     } else {
       // Step is a result step

--- a/src/client/workflow/workflow-parser.ts
+++ b/src/client/workflow/workflow-parser.ts
@@ -2,6 +2,7 @@ import type { Err, Ok } from "neverthrow";
 import { err, ok } from "neverthrow";
 import { QstashWorkflowError } from "../error";
 import {
+  NO_CONCURRENCY,
   WORKFLOW_FAILURE_HEADER,
   WORKFLOW_ID_HEADER,
   WORKFLOW_PROTOCOL_VERSION,
@@ -60,7 +61,7 @@ const parsePayload = (rawPayload: string) => {
     stepName: "init",
     stepType: "Initial",
     out: rawInitialPayload,
-    concurrent: 1,
+    concurrent: NO_CONCURRENCY,
   };
 
   // remove "toCallback" and "fromCallback" steps:

--- a/src/client/workflow/workflow-requests.test.ts
+++ b/src/client/workflow/workflow-requests.test.ts
@@ -179,7 +179,7 @@ describe("Workflow Requests", () => {
       // create mock server and run the code
       await mockQstashServer({
         execute: async () => {
-          const result = await handleThirdPartyCallResult(request, client);
+          const result = await handleThirdPartyCallResult(request, await request.text(), client);
           expect(result.isOk());
           // @ts-expect-error value will be set since stepFinish isOk
           expect(result.value).toBe("is-call-return");
@@ -237,7 +237,7 @@ describe("Workflow Requests", () => {
       });
 
       const spy = spyOn(client, "publishJSON");
-      const result = await handleThirdPartyCallResult(request, client);
+      const result = await handleThirdPartyCallResult(request, await request.text(), client);
       expect(result.isOk()).toBeTrue();
       // @ts-expect-error value will be set since stepFinish isOk
       expect(result.value).toBe("call-will-retry");
@@ -280,14 +280,22 @@ describe("Workflow Requests", () => {
       });
 
       const spy = spyOn(client, "publishJSON");
-      const initialResult = await handleThirdPartyCallResult(initialRequest, client);
+      const initialResult = await handleThirdPartyCallResult(
+        initialRequest,
+        await initialRequest.text(),
+        client
+      );
       expect(initialResult.isOk());
       // @ts-expect-error value will be set since stepFinish isOk
       expect(initialResult.value).toBe("continue-workflow");
       expect(spy).toHaveBeenCalledTimes(0);
 
       // second call
-      const result = await handleThirdPartyCallResult(workflowRequest, client);
+      const result = await handleThirdPartyCallResult(
+        workflowRequest,
+        await workflowRequest.text(),
+        client
+      );
       expect(result.isOk()).toBeTrue();
       // @ts-expect-error value will be set since stepFinish isOk
       expect(result.value).toBe("continue-workflow");

--- a/src/client/workflow/workflow-requests.test.ts
+++ b/src/client/workflow/workflow-requests.test.ts
@@ -14,6 +14,7 @@ import { WorkflowContext } from "./context";
 import { Client } from "../client";
 import type { Step, StepType } from "./types";
 import {
+  WORKFLOW_FAILURE_HEADER,
   WORKFLOW_ID_HEADER,
   WORKFLOW_INIT_HEADER,
   WORKFLOW_PROTOCOL_VERSION,
@@ -179,7 +180,12 @@ describe("Workflow Requests", () => {
       // create mock server and run the code
       await mockQstashServer({
         execute: async () => {
-          const result = await handleThirdPartyCallResult(request, await request.text(), client);
+          const result = await handleThirdPartyCallResult(
+            request,
+            await request.text(),
+            client,
+            WORKFLOW_ENDPOINT
+          );
           expect(result.isOk());
           // @ts-expect-error value will be set since stepFinish isOk
           expect(result.value).toBe("is-call-return");
@@ -237,7 +243,12 @@ describe("Workflow Requests", () => {
       });
 
       const spy = spyOn(client, "publishJSON");
-      const result = await handleThirdPartyCallResult(request, await request.text(), client);
+      const result = await handleThirdPartyCallResult(
+        request,
+        await request.text(),
+        client,
+        WORKFLOW_ENDPOINT
+      );
       expect(result.isOk()).toBeTrue();
       // @ts-expect-error value will be set since stepFinish isOk
       expect(result.value).toBe("call-will-retry");
@@ -283,7 +294,8 @@ describe("Workflow Requests", () => {
       const initialResult = await handleThirdPartyCallResult(
         initialRequest,
         await initialRequest.text(),
-        client
+        client,
+        WORKFLOW_ENDPOINT
       );
       expect(initialResult.isOk());
       // @ts-expect-error value will be set since stepFinish isOk
@@ -294,7 +306,8 @@ describe("Workflow Requests", () => {
       const result = await handleThirdPartyCallResult(
         workflowRequest,
         await workflowRequest.text(),
-        client
+        client,
+        WORKFLOW_ENDPOINT
       );
       expect(result.isOk()).toBeTrue();
       // @ts-expect-error value will be set since stepFinish isOk
@@ -374,6 +387,26 @@ describe("Workflow Requests", () => {
         "Upstash-Callback-Workflow-Url": WORKFLOW_ENDPOINT,
         "Upstash-Forward-my-custom-header": "my-custom-header-value",
         "Upstash-Workflow-CallType": "toCallback",
+      });
+    });
+
+    test("should include failure header", () => {
+      const failureUrl = "https://my-failure-endpoint.com";
+      const headers = getHeaders(
+        "true",
+        workflowRunId,
+        WORKFLOW_ENDPOINT,
+        new Headers() as Headers,
+        undefined,
+        failureUrl
+      );
+      expect(headers).toEqual({
+        [WORKFLOW_INIT_HEADER]: "true",
+        [WORKFLOW_ID_HEADER]: workflowRunId,
+        [WORKFLOW_URL_HEADER]: WORKFLOW_ENDPOINT,
+        [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
+        [`Upstash-Failure-Callback-Forward-${WORKFLOW_FAILURE_HEADER}`]: "true",
+        "Upstash-Failure-Callback": failureUrl,
       });
     });
   });

--- a/src/client/workflow/workflow-requests.test.ts
+++ b/src/client/workflow/workflow-requests.test.ts
@@ -198,7 +198,6 @@ describe("Workflow Requests", () => {
             stepType: stepType,
             out: thirdPartyCallResult,
             concurrent: 1,
-            targetStep: 0,
           },
         },
       });
@@ -254,7 +253,6 @@ describe("Workflow Requests", () => {
           stepName: "step name",
           stepType: "Run",
           concurrent: 1,
-          targetStep: 0,
         },
       ];
       const workflowRunId = nanoid();
@@ -319,7 +317,6 @@ describe("Workflow Requests", () => {
         stepName,
         stepType: stepType,
         concurrent: 1,
-        targetStep: 0,
       });
       expect(headers).toEqual({
         [WORKFLOW_INIT_HEADER]: "false",
@@ -345,7 +342,6 @@ describe("Workflow Requests", () => {
         stepName,
         stepType: stepType,
         concurrent: 1,
-        targetStep: 0,
         callUrl,
         callMethod,
         callHeaders,

--- a/src/client/workflow/workflow-requests.ts
+++ b/src/client/workflow/workflow-requests.ts
@@ -5,13 +5,14 @@ import type { WorkflowContext } from "./context";
 import type { Client } from "../client";
 import {
   DEFAULT_CONTENT_TYPE,
+  WORKFLOW_FAILURE_HEADER,
   WORKFLOW_ID_HEADER,
   WORKFLOW_INIT_HEADER,
   WORKFLOW_PROTOCOL_VERSION,
   WORKFLOW_PROTOCOL_VERSION_HEADER,
   WORKFLOW_URL_HEADER,
 } from "./constants";
-import type { Step, StepType } from "./types";
+import type { Step, StepType, WorkflowServeOptions } from "./types";
 import { StepTypes } from "./types";
 import type { WorkflowLogger } from "./logger";
 import type { Receiver } from "../../receiver";
@@ -24,7 +25,9 @@ export const triggerFirstInvocation = async <TInitialPayload>(
     "true",
     workflowContext.workflowRunId,
     workflowContext.url,
-    workflowContext.headers
+    workflowContext.headers,
+    undefined,
+    workflowContext.failureUrl
   );
   await debug?.log("SUBMIT", "SUBMIT_FIRST_INVOCATION", {
     headers,
@@ -122,6 +125,7 @@ export const handleThirdPartyCallResult = async (
   request: Request,
   requestPayload: string,
   client: Client,
+  failureUrl: WorkflowServeOptions["failureUrl"],
   debug?: WorkflowLogger
 ): Promise<
   Ok<"is-call-return" | "continue-workflow" | "call-will-retry", never> | Err<never, Error>
@@ -170,7 +174,14 @@ export const handleThirdPartyCallResult = async (
       }
 
       const userHeaders = recreateUserHeaders(request.headers as Headers);
-      const requestHeaders = getHeaders("false", workflowRunId, request.url, userHeaders);
+      const requestHeaders = getHeaders(
+        "false",
+        workflowRunId,
+        request.url,
+        userHeaders,
+        undefined,
+        failureUrl
+      );
 
       const callResultStep: Step = {
         stepId: Number(stepIdString),
@@ -226,13 +237,20 @@ export const getHeaders = (
   workflowRunId: string,
   workflowUrl: string,
   userHeaders?: Headers,
-  step?: Step
+  step?: Step,
+  failureUrl?: WorkflowServeOptions["failureUrl"]
 ): Record<string, string> => {
   const baseHeaders: Record<string, string> = {
     [WORKFLOW_INIT_HEADER]: initHeaderValue,
     [WORKFLOW_ID_HEADER]: workflowRunId,
     [WORKFLOW_URL_HEADER]: workflowUrl,
     [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
+    ...(failureUrl
+      ? {
+          [`Upstash-Failure-Callback-Forward-${WORKFLOW_FAILURE_HEADER}`]: "true",
+          "Upstash-Failure-Callback": failureUrl,
+        }
+      : {}),
   };
 
   if (userHeaders) {

--- a/src/client/workflow/workflow-requests.ts
+++ b/src/client/workflow/workflow-requests.ts
@@ -120,18 +120,15 @@ export const recreateUserHeaders = (headers: Headers): Headers => {
  */
 export const handleThirdPartyCallResult = async (
   request: Request,
+  requestPayload: string,
   client: Client,
-  debug?: WorkflowLogger,
-  verifier?: Receiver
+  debug?: WorkflowLogger
 ): Promise<
   Ok<"is-call-return" | "continue-workflow" | "call-will-retry", never> | Err<never, Error>
 > => {
   try {
     if (request.headers.get("Upstash-Workflow-Callback")) {
-      const callbackBody = await request.text();
-      await verifyRequest(callbackBody, request.headers.get("upstash-signature"), verifier);
-
-      const callbackMessage = JSON.parse(callbackBody) as {
+      const callbackMessage = JSON.parse(requestPayload) as {
         status: number;
         body: string;
       };

--- a/src/client/workflow/workflow-requests.ts
+++ b/src/client/workflow/workflow-requests.ts
@@ -181,7 +181,6 @@ export const handleThirdPartyCallResult = async (
         stepType,
         out: Buffer.from(callbackMessage.body, "base64").toString(),
         concurrent: Number(concurrentString),
-        targetStep: 0,
       };
 
       await debug?.log("SUBMIT", "SUBMIT_THIRD_PARTY_RESULT", {

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -3,7 +3,6 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: {
     index: "./src/index.ts",
-    nextjs: "./src/nextjs.ts",
     workflow: "./src/client/workflow/index.ts",
     nextjs: "./platforms/nextjs.ts",
     nuxt: "./platforms/nuxt.ts",


### PR DESCRIPTION
This PR has a lot of changes explained in each commit in detail.

### Fix Parallel Step Fields d3c1ea2af603f65c86c40f2d6f7abde3927883a6

- When a sleep/sleepUntil step ran, it only had the `sleepFor`/`sleepUntil` fields in the plan step. Not in the result step.
- `concurrent` field of result steps were always 1 in parallel steps. This is fixed to be the actual concurrency.

### Test: Incompatible Step Name/Type 17325a6e46ae1ef37b7e021263dc43b961976167

Tests didn't exist for #131. Added tests.

### Test: End-to-end test for error during step 32cc2fd27050959a096e6dba0b012b699b77719b

Title explains the test.

### Make targetStep optional eddc33cce4b2835b6d15c97ffb8d6c6dfb4bbb56

`targetStep` field of `Step` was not optional and it was set to 0 in result steps. Made it optional to match the backend.

### Feature: Authentication 7b466bd7690bfd36722937e5d585ec1807bd19ee

It is now possible to check for authentication in routeFunction like:
```ts
export const POST = serve({
  routeFunction: (context) => {
    const auth = context.headers.get("authentication")
    if (!checkAuth(auth)) {
      // auth failed
      return
    }
  }
})
```

This is made possible with the new `DisabledWorkflowContext`. Before running the `routeFunction` properly, we run it with the new `DisabledWorkflowContext` which raises whenever it comes across a step (without running it).

This makes it possible to run the auth section in the beginning of the code before any execution everytime. Making it possible to secure an endpoint without QStash verification.

Caveat: I don't like how this turned out in the code. It is too complex. A simpler solution is to have a `onInvocation` callback and let the user do whatever they want with the incoming event/request. Another problem is that we call the auth section twice everytime the endpoint is called.

### Remove nonPlanStepCount from context fields a1513f7de1322fddb3c6762242e245a274a13430

removed the public field and made it internal.

### Feature: Error handling b1c2df7fa1f539720dcfe515b7c6fc84938448b0

It is now possible to determine error handling:

Option 1, pass failure URL to be called when retries are exhausted:
```ts
export const POST = serve({
  routeFunction: (context) => {
    const auth = context.headers.get("authentication")
    if (!checkAuth(auth)) {
      // auth failed
      return
    }
  },
  options: {
    failureUrl: "my-failure-endpoint"
  }
})
```
Option 2, pass a function to be called on error:
```ts
export const POST = serve({
  routeFunction: (context) => {
    const auth = context.headers.get("authentication")
    if (!checkAuth(auth)) {
      // auth failed
      return
    }
  },
  options: {
    // fields come from callback body. see: https://upstash.com/docs/qstash/features/callbacks#what-is-a-failure-callback
    failureFunction: (status, header, body) => {
      // do something
    }
  }
})
```

If neither is passed, nothing happens.