### PR TITLE
Workflow: Feedback & Failure Body

### DIFF
--- a/examples/workflow/bootstrap.sh
+++ b/examples/workflow/bootstrap.sh
@@ -14,7 +14,7 @@ project_arg="$1"
 path_arg="$2"
 
 # Start ngrok and capture the public URL
-ngrok http localhost:3000 --log=stdout > ngrok.log &
+ngrok http localhost:3001 --log=stdout > ngrok.log &
 NGROK_PID=$!
 sleep 5  # Allow some time for ngrok to start
 

--- a/examples/workflow/nextjs/app/sleep/route.ts
+++ b/examples/workflow/nextjs/app/sleep/route.ts
@@ -22,7 +22,7 @@ export const POST = serve<string>({
       return output
     });
 
-    await context.sleep("sleep2", 2)
+    await context.sleep("sleep2", 3600)
 
     const result3 = await context.run("step3", async () => {
       const output = someWork(result2)

--- a/examples/workflow/nextjs/app/sleep/route.ts
+++ b/examples/workflow/nextjs/app/sleep/route.ts
@@ -22,7 +22,7 @@ export const POST = serve<string>({
       return output
     });
 
-    await context.sleep("sleep2", 3600)
+    await context.sleep("sleep2", 2)
 
     const result3 = await context.run("step3", async () => {
       const output = someWork(result2)

--- a/examples/workflow/nextjs/app/sleepWithoutAwait/route.ts
+++ b/examples/workflow/nextjs/app/sleepWithoutAwait/route.ts
@@ -53,7 +53,7 @@ export const POST = serve<Invoice>({
             console.log(x, "  send receipt", charge.invoice.email);
             return 10
           }),
-          context.sleep("sleep", 5)
+          context.sleep("sleep", 3600)
         ])
         console.log("end", updateDb, receipt, wait);
         return

--- a/examples/workflow/nextjs/app/sleepWithoutAwait/route.ts
+++ b/examples/workflow/nextjs/app/sleepWithoutAwait/route.ts
@@ -53,7 +53,7 @@ export const POST = serve<Invoice>({
             console.log(x, "  send receipt", charge.invoice.email);
             return 10
           }),
-          context.sleep("sleep", 3600)
+          context.sleep("sleep", 5)
         ])
         console.log("end", updateDb, receipt, wait);
         return

--- a/examples/workflow/nextjs/package.json
+++ b/examples/workflow/nextjs/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 3001",
     "lint": "next lint"
   },
   "dependencies": {

--- a/examples/workflow/nuxt/nuxt.config.ts
+++ b/examples/workflow/nuxt/nuxt.config.ts
@@ -14,6 +14,6 @@ export default defineNuxtConfig({
     },
   },
   devServer: {
-    port: 3000
+    port: 3001
   }
 })

--- a/examples/workflow/sveltekit/src/routes/northStar/+server.ts
+++ b/examples/workflow/sveltekit/src/routes/northStar/+server.ts
@@ -66,7 +66,7 @@ export const POST = serve<Invoice>({
       return true
     })
   },
-  client: new Client({
+  qstashClient: new Client({
     baseUrl: env.QSTASH_URL!,
     token: env.QSTASH_TOKEN!,
   }),

--- a/examples/workflow/sveltekit/src/routes/northStarSimple/+server.ts
+++ b/examples/workflow/sveltekit/src/routes/northStarSimple/+server.ts
@@ -60,7 +60,7 @@ export const POST = serve<Invoice>({
       return true
     })
   },
-  client: new Client({
+  qstashClient: new Client({
     baseUrl: env.QSTASH_URL!,
     token: env.QSTASH_TOKEN!,
   }),

--- a/examples/workflow/sveltekit/src/routes/path/+server.ts
+++ b/examples/workflow/sveltekit/src/routes/path/+server.ts
@@ -20,7 +20,7 @@ export const POST = serve<string>({
       console.log("step 2 input", result1, "output", output)
     });
   },
-  client: new Client({
+  qstashClient: new Client({
     baseUrl: env.QSTASH_URL!,
     token: env.QSTASH_TOKEN!,
   }),

--- a/examples/workflow/sveltekit/src/routes/sleep/+server.ts
+++ b/examples/workflow/sveltekit/src/routes/sleep/+server.ts
@@ -30,7 +30,7 @@ export const POST = serve<string>({
       console.log("step 3 input", result2, "output", output)
     });
   },
-  client: new Client({
+  qstashClient: new Client({
     baseUrl: env.QSTASH_URL!,
     token: env.QSTASH_TOKEN!,
   }),

--- a/examples/workflow/sveltekit/src/routes/sleepWithoutAwait/+server.ts
+++ b/examples/workflow/sveltekit/src/routes/sleepWithoutAwait/+server.ts
@@ -66,7 +66,7 @@ export const POST = serve<Invoice>({
       return true
     })
   },
-  client: new Client({
+  qstashClient: new Client({
     baseUrl: env.QSTASH_URL!,
     token: env.QSTASH_TOKEN!,
   }),

--- a/examples/workflow/sveltekit/vite.config.ts
+++ b/examples/workflow/sveltekit/vite.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
         preserveSymlinks: true,
     },
     server: {
-      port: 3000,
+      port: 3001,
     },
 });

--- a/platforms/nextjs.ts
+++ b/platforms/nextjs.ts
@@ -199,7 +199,7 @@ export function verifySignatureAppRouter(
 export const serve = <TInitialPayload = unknown>({
   routeFunction,
   options,
-}: WorkflowServeParameters<TInitialPayload, NextResponse>): ((
+}: WorkflowServeParameters<TInitialPayload, NextResponse, "onStepFinish">): ((
   request: NextRequest
 ) => Promise<NextResponse>) => {
   const handler = serveBase<TInitialPayload, NextRequest, NextResponse>({

--- a/platforms/nuxt.ts
+++ b/platforms/nuxt.ts
@@ -70,7 +70,7 @@ function transformHeaders(headers: IncomingHttpHeaders): [string, string][] {
 export const serve = <TInitialPayload = unknown>({
   routeFunction,
   options,
-}: WorkflowServeParameters<TInitialPayload>) => {
+}: WorkflowServeParameters<TInitialPayload, Response, "onStepFinish">) => {
   const handler = defineEventHandler(async (event) => {
     const method = event.node.req.method;
     if (method?.toUpperCase() !== "POST") {

--- a/platforms/nuxt.ts
+++ b/platforms/nuxt.ts
@@ -1,6 +1,6 @@
 import type { H3Event } from "h3";
 import { defineEventHandler, getHeader, readRawBody } from "h3";
-import { Receiver } from "../src";
+import { formatWorkflowError, Receiver } from "../src";
 
 import type { WorkflowServeParameters } from "../src/client/workflow";
 import { serve as serveBase } from "../src/client/workflow";
@@ -70,7 +70,7 @@ function transformHeaders(headers: IncomingHttpHeaders): [string, string][] {
 export const serve = <TInitialPayload = unknown>({
   routeFunction,
   options,
-}: WorkflowServeParameters<TInitialPayload, string>) => {
+}: WorkflowServeParameters<TInitialPayload>) => {
   const handler = defineEventHandler(async (event) => {
     const method = event.node.req.method;
     if (method?.toUpperCase() !== "POST") {
@@ -92,24 +92,14 @@ export const serve = <TInitialPayload = unknown>({
       method: "POST",
     });
 
-    const serveHandler = serveBase<TInitialPayload, Request, string>({
+    const serveHandler = serveBase<TInitialPayload>({
       routeFunction,
-      options: {
-        onStepFinish: (workflowRunId: string) => workflowRunId,
-        ...options,
-      },
+      options,
     });
     try {
-      const workflowRunId = await serveHandler(request);
-      return {
-        status: 200,
-        body: { workflowRunId },
-      };
+      return await serveHandler(request);
     } catch (error) {
-      return {
-        status: 500,
-        body: `Error running the workflow at URL '${url}'. Got error: ${error}`,
-      };
+      return new Response(JSON.stringify(formatWorkflowError(error)), { status: 500 });
     }
   });
   return handler;

--- a/platforms/solidjs.ts
+++ b/platforms/solidjs.ts
@@ -1,5 +1,5 @@
 import type { APIEvent, APIHandler } from "@solidjs/start/server";
-import { Receiver } from "../src";
+import { formatWorkflowError, Receiver } from "../src";
 
 import type { WorkflowServeParameters } from "../src/client/workflow";
 import { serve as serveBase } from "../src/client/workflow";
@@ -68,7 +68,12 @@ export const serve = <TInitialPayload = unknown>({
     });
 
     // invoke serve handler and return result
-    return serveHandler(event.request);
+    try {
+      const result = await serveHandler(event.request);
+      return result;
+    } catch (error) {
+      return new Response(JSON.stringify(formatWorkflowError(error)), { status: 500 });
+    }
   };
   return handler;
 };

--- a/platforms/solidjs.ts
+++ b/platforms/solidjs.ts
@@ -51,7 +51,7 @@ export const verifySignatureSolidjs = (
 export const serve = <TInitialPayload = unknown>({
   routeFunction,
   options,
-}: WorkflowServeParameters<TInitialPayload>) => {
+}: WorkflowServeParameters<TInitialPayload, Response, "onStepFinish">) => {
   // Create a handler which receives an event and calls the
   // serveBase method
   const handler = async (event: APIEvent) => {

--- a/platforms/svelte.ts
+++ b/platforms/svelte.ts
@@ -57,7 +57,7 @@ export const serve = <TInitialPayload = unknown>({
   options,
   receiver,
   qstashClient,
-}: WorkflowServeParametersExtended<TInitialPayload>): RequestHandler => {
+}: WorkflowServeParametersExtended<TInitialPayload, Response, "onStepFinish">): RequestHandler => {
   const handler: RequestHandler = async ({ request }) => {
     const serveMethod = serveBase<TInitialPayload>({
       routeFunction,

--- a/platforms/svelte.ts
+++ b/platforms/svelte.ts
@@ -56,13 +56,13 @@ export const serve = <TInitialPayload = unknown>({
   routeFunction,
   options,
   receiver,
-  client,
+  qstashClient,
 }: WorkflowServeParametersExtended<TInitialPayload>): RequestHandler => {
   const handler: RequestHandler = ({ request }) => {
     const serveMethod = serveBase<TInitialPayload>({
       routeFunction,
       options: {
-        client,
+        qstashClient,
         receiver,
         ...options,
       },

--- a/platforms/svelte.ts
+++ b/platforms/svelte.ts
@@ -1,5 +1,5 @@
 import type { RequestHandler } from "@sveltejs/kit";
-import { Receiver } from "../src";
+import { formatWorkflowError, Receiver } from "../src";
 
 import type { WorkflowServeParametersExtended } from "../src/client/workflow";
 import { serve as serveBase } from "../src/client/workflow";
@@ -58,7 +58,7 @@ export const serve = <TInitialPayload = unknown>({
   receiver,
   qstashClient,
 }: WorkflowServeParametersExtended<TInitialPayload>): RequestHandler => {
-  const handler: RequestHandler = ({ request }) => {
+  const handler: RequestHandler = async ({ request }) => {
     const serveMethod = serveBase<TInitialPayload>({
       routeFunction,
       options: {
@@ -67,7 +67,11 @@ export const serve = <TInitialPayload = unknown>({
         ...options,
       },
     });
-    return serveMethod(request);
+    try {
+      return await serveMethod(request);
+    } catch (error) {
+      return new Response(JSON.stringify(formatWorkflowError(error)), { status: 500 });
+    }
   };
 
   return handler;

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -9,6 +9,7 @@ import { Schedules } from "./schedules";
 import type { BodyInit, Event, GetEventsPayload, HeadersInit, HTTPMethods, State } from "./types";
 import { UrlGroups } from "./url-groups";
 import { getRequestPath, prefixHeaders, processHeaders } from "./utils";
+import { Workflow } from "./workflow";
 
 type ClientConfig = {
   /**
@@ -306,6 +307,15 @@ export class Client {
    */
   public get schedules(): Schedules {
     return new Schedules(this.http);
+  }
+
+  /**
+   * Access the workflow API.
+   *
+   * cancel workflows.
+   */
+  public get workflow(): Workflow {
+    return new Workflow(this.http);
   }
 
   /**

--- a/src/client/error.ts
+++ b/src/client/error.ts
@@ -1,5 +1,5 @@
 import type { ChatRateLimit, RateLimit } from "./types";
-import type { Step } from "./workflow/types";
+import type { FailureFunctionPayload, Step } from "./workflow/types";
 
 /**
  * Result of 500 Internal Server Error
@@ -82,3 +82,22 @@ export class QstashWorkflowAbort extends Error {
     this.stepInfo = stepInfo;
   }
 }
+
+/**
+ * Formats an unknown error to match the FailureFunctionPayload format
+ *
+ * @param error
+ * @returns
+ */
+export const formatWorkflowError = (error: unknown): FailureFunctionPayload => {
+  return error instanceof Error
+    ? {
+        error: error.name,
+        message: error.message,
+        stack: error.stack,
+      }
+    : {
+        error: "Error",
+        message: "An error occured while executing workflow.",
+      };
+};

--- a/src/client/workflow.test.ts
+++ b/src/client/workflow.test.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { describe, test, expect } from "bun:test";
+import { triggerFirstInvocation } from "./workflow/workflow-requests";
+import { WorkflowContext } from "./workflow/context";
+import { nanoid } from "nanoid";
+import { Client } from "./client";
+import { QstashError } from "./error";
+
+describe("workflow tests", () => {
+  const qstashClient = new Client({ token: process.env.QSTASH_TOKEN! });
+  test("should delete workflow succesfully", async () => {
+    const workflowRunId = `wfr-${nanoid()}`;
+    const result = await triggerFirstInvocation(
+      new WorkflowContext({
+        qstashClient,
+        workflowRunId,
+        headers: new Headers({}) as Headers,
+        steps: [],
+        url: "https://some-url.com",
+        initialPayload: undefined,
+      })
+    );
+    expect(result.isOk()).toBeTrue();
+
+    const cancelResult = await qstashClient.workflow.cancel(workflowRunId);
+    expect(cancelResult).toBeTrue();
+
+    const throws = qstashClient.workflow.cancel(workflowRunId);
+    expect(throws).rejects.toThrow(
+      new QstashError(`{"error":"workflowRun ${workflowRunId} not found"}`)
+    );
+  });
+});

--- a/src/client/workflow/auto-executor.test.ts
+++ b/src/client/workflow/auto-executor.test.ts
@@ -85,7 +85,7 @@ describe("auto-executor", () => {
 
   const getContext = (steps: Step[]) => {
     return new SpyWorkflowContext({
-      client: new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token }),
+      qstashClient: new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token }),
       workflowRunId,
       initialPayload,
       headers: new Headers({}) as Headers,

--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -318,7 +318,7 @@ export class AutoExecutor {
 
     await this.debug?.log("SUBMIT", "SUBMIT_STEP", { length: steps.length, steps });
 
-    const result = await this.context.client.batchJSON(
+    const result = await this.context.qstashClient.batchJSON(
       steps.map((singleStep) => {
         const headers = getHeaders(
           "false",

--- a/src/client/workflow/context.test.ts
+++ b/src/client/workflow/context.test.ts
@@ -10,10 +10,10 @@ import type { RouteFunction } from "./types";
 
 describe("context tests", () => {
   const token = nanoid();
-  const client = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
+  const qstashClient = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
   test("should raise when there are nested steps (with run)", () => {
     const context = new WorkflowContext({
-      client,
+      qstashClient,
       initialPayload: "my-payload",
       steps: [],
       url: WORKFLOW_ENDPOINT,
@@ -37,7 +37,7 @@ describe("context tests", () => {
 
   test("should raise when there are nested steps (with sleep)", () => {
     const context = new WorkflowContext({
-      client,
+      qstashClient,
       initialPayload: "my-payload",
       steps: [],
       url: WORKFLOW_ENDPOINT,
@@ -59,7 +59,7 @@ describe("context tests", () => {
 
   test("should raise when there are nested steps (with sleepUntil)", () => {
     const context = new WorkflowContext({
-      client,
+      qstashClient,
       initialPayload: "my-payload",
       steps: [],
       url: WORKFLOW_ENDPOINT,
@@ -81,7 +81,7 @@ describe("context tests", () => {
 
   test("should raise when there are nested steps (with call)", () => {
     const context = new WorkflowContext({
-      client,
+      qstashClient,
       initialPayload: "my-payload",
       steps: [],
       url: WORKFLOW_ENDPOINT,
@@ -103,7 +103,7 @@ describe("context tests", () => {
 
   test("should not raise when there are no nested steps", async () => {
     const context = new WorkflowContext({
-      client,
+      qstashClient,
       initialPayload: "my-payload",
       steps: [],
       url: WORKFLOW_ENDPOINT,
@@ -149,9 +149,9 @@ describe("context tests", () => {
 
 describe("disabled workflow context", () => {
   const token = nanoid();
-  const client = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
+  const qstashClient = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
   const disabledContext = new DisabledWorkflowContext({
-    client,
+    qstashClient,
     workflowRunId: "wfr-foo",
     headers: new Headers() as Headers,
     steps: [],
@@ -233,7 +233,7 @@ describe("disabled workflow context", () => {
 
   describe("tryAuthentication", () => {
     const disabledContext = new DisabledWorkflowContext({
-      client,
+      qstashClient,
       workflowRunId: "wfr-foo",
       headers: new Headers() as Headers,
       steps: [],

--- a/src/client/workflow/context.ts
+++ b/src/client/workflow/context.ts
@@ -12,10 +12,10 @@ import { QstashWorkflowAbort } from "../error";
 
 export class WorkflowContext<TInitialPayload = unknown> {
   protected readonly executor: AutoExecutor;
+  protected readonly steps: Step[];
 
   public readonly client: Client;
   public readonly workflowRunId: string;
-  public readonly steps: Step[];
   public readonly url: string;
   public readonly failureUrl: string | false;
   public readonly requestPayload: TInitialPayload;
@@ -52,7 +52,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     this.requestPayload = initialPayload;
     this.rawInitialPayload = rawInitialPayload ?? JSON.stringify(this.requestPayload);
 
-    this.executor = new AutoExecutor(this, debug);
+    this.executor = new AutoExecutor(this, this.steps, debug);
   }
 
   /**
@@ -203,7 +203,7 @@ export class DisabledWorkflowContext<
       client: new Client({ baseUrl: "disabled-client", token: "disabled-client" }),
       workflowRunId: context.workflowRunId,
       headers: context.headers,
-      steps: context.steps,
+      steps: [],
       url: context.url,
       failureUrl: context.failureUrl,
       initialPayload: context.requestPayload,

--- a/src/client/workflow/context.ts
+++ b/src/client/workflow/context.ts
@@ -14,7 +14,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
   protected readonly executor: AutoExecutor;
   protected readonly steps: Step[];
 
-  public readonly client: Client;
+  public readonly qstashClient: Client;
   public readonly workflowRunId: string;
   public readonly url: string;
   public readonly failureUrl: string | false;
@@ -23,7 +23,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
   public readonly rawInitialPayload: string;
 
   constructor({
-    client,
+    qstashClient,
     workflowRunId,
     headers,
     steps,
@@ -33,7 +33,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     initialPayload,
     rawInitialPayload,
   }: {
-    client: Client;
+    qstashClient: Client;
     workflowRunId: string;
     headers: Headers;
     steps: Step[];
@@ -43,7 +43,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
     initialPayload: TInitialPayload;
     rawInitialPayload?: string; // optional for tests
   }) {
-    this.client = client;
+    this.qstashClient = qstashClient;
     this.workflowRunId = workflowRunId;
     this.steps = steps;
     this.url = url;
@@ -200,7 +200,7 @@ export class DisabledWorkflowContext<
     context: WorkflowContext<TInitialPayload>
   ): Promise<Ok<"step-found" | "run-ended", never> | Err<never, Error>> {
     const disabledContext = new DisabledWorkflowContext({
-      client: new Client({ baseUrl: "disabled-client", token: "disabled-client" }),
+      qstashClient: new Client({ baseUrl: "disabled-client", token: "disabled-client" }),
       workflowRunId: context.workflowRunId,
       headers: context.headers,
       steps: [],

--- a/src/client/workflow/index.ts
+++ b/src/client/workflow/index.ts
@@ -1,4 +1,29 @@
+import type { Requester } from "../http";
+
 export * from "./serve";
 export * from "./context";
 export * from "./types";
 export * from "./logger";
+
+export class Workflow {
+  private readonly http;
+
+  constructor(http: Requester) {
+    this.http = http;
+  }
+
+  /**
+   * Cancel an ongoing workflow
+   *
+   * @param workflowRunId run id of the workflow to delete
+   * @returns true if workflow is succesfully deleted. Otherwise throws QStashError
+   */
+  public async cancel(workflowRunId: string) {
+    const result = (await this.http.request({
+      path: ["v2", "workflows", "runs", `${workflowRunId}?cancel=true`],
+      method: "DELETE",
+      parseResponseAsJson: false,
+    })) as { error: string } | undefined;
+    return result ?? true;
+  }
+}

--- a/src/client/workflow/integration.test.ts
+++ b/src/client/workflow/integration.test.ts
@@ -95,7 +95,7 @@ const attemptCharge = () => {
   return false;
 };
 
-const client = new Client({
+const qstashClient = new Client({
   baseUrl: process.env.MOCK_QSTASH_URL,
   token: process.env.MOCK_QSTASH_TOKEN ?? "",
 });
@@ -118,7 +118,7 @@ const testEndpoint = async <TInitialPayload = unknown>({
   const endpoint = workflowServe<TInitialPayload>({
     routeFunction,
     options: {
-      client,
+      qstashClient,
       url: LOCAL_WORKFLOW_URL,
       verbose: true,
     },
@@ -132,7 +132,7 @@ const testEndpoint = async <TInitialPayload = unknown>({
     port: WORKFLOW_PORT,
   });
 
-  await client.publishJSON({
+  await qstashClient.publishJSON({
     method: "POST",
     body: initialPayload,
     headers: {

--- a/src/client/workflow/integration.test.ts
+++ b/src/client/workflow/integration.test.ts
@@ -171,7 +171,6 @@ describe.skip("live serve tests", () => {
           expect(result1).toBe("processed 'my-payload'");
 
           const result2 = await context.run("step2", async () => {
-            // console.log("step2 ran", result1);
             const result = someWork(result1);
             return await Promise.resolve(result);
           });
@@ -305,7 +304,6 @@ describe.skip("live serve tests", () => {
           expect(result1).toBe("processed 'my-payload'");
 
           const result2 = await context.run("step2", async () => {
-            // console.log("step2 ran", result1);
             const result = someWork(result1);
             return await Promise.resolve(result);
           });

--- a/src/client/workflow/receiver.test.ts
+++ b/src/client/workflow/receiver.test.ts
@@ -80,7 +80,7 @@ const nextSigningKey = nanoid();
 const randomBody = btoa(nanoid());
 
 const token = nanoid();
-const client = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
+const qstashClient = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
 const receiver = new Receiver({ currentSigningKey, nextSigningKey });
 
 /**
@@ -93,7 +93,7 @@ const endpoint = serve({
     });
   },
   options: {
-    client,
+    qstashClient,
     receiver,
     url: WORKFLOW_ENDPOINT,
   },

--- a/src/client/workflow/serve.test.ts
+++ b/src/client/workflow/serve.test.ts
@@ -21,7 +21,7 @@ const someWork = (input: string) => {
 const workflowRunId = `wfr${nanoid()}`;
 const token = nanoid();
 
-const client = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
+const qstashClient = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
 
 describe("serve", () => {
   test("should send create workflow request in initial request", async () => {
@@ -31,7 +31,7 @@ describe("serve", () => {
         await context.sleep("sleep 1", 1);
       },
       options: {
-        client,
+        qstashClient,
         verbose: true,
         receiver: false,
       },
@@ -73,7 +73,7 @@ describe("serve", () => {
         });
       },
       options: {
-        client,
+        qstashClient,
         verbose: true,
         receiver: false,
       },
@@ -172,7 +172,7 @@ describe("serve", () => {
         });
       },
       options: {
-        client,
+        qstashClient,
         receiver: false,
       },
     });
@@ -200,7 +200,7 @@ describe("serve", () => {
         return;
       },
       options: {
-        client,
+        qstashClient,
         receiver: false,
       },
     });
@@ -238,7 +238,7 @@ describe("serve", () => {
         });
       },
       options: {
-        client,
+        qstashClient,
         receiver: false,
       },
     });
@@ -325,7 +325,7 @@ describe("serve", () => {
       const endpoint = serve({
         routeFunction,
         options: {
-          client,
+          qstashClient,
           receiver: false,
         },
       });
@@ -366,7 +366,7 @@ describe("serve", () => {
       const endpoint = serve({
         routeFunction,
         options: {
-          client,
+          qstashClient,
           receiver: false,
           failureUrl: myFailureEndpoint,
         },
@@ -418,7 +418,7 @@ describe("serve", () => {
       const endpoint = serve({
         routeFunction,
         options: {
-          client,
+          qstashClient,
           receiver: false,
           failureFunction: myFailureFunction,
         },

--- a/src/client/workflow/serve.ts
+++ b/src/client/workflow/serve.ts
@@ -166,7 +166,7 @@ export const serve = <
     );
     if (authCheck.isErr()) {
       // got error while running until first step
-      await debug?.log("ERROR", "ERROR", { error: authCheck.error });
+      await debug?.log("ERROR", "ERROR", { error: authCheck.error.message });
       throw authCheck.error;
     } else if (authCheck.value === "run-ended") {
       // finished routeFunction while trying to run until first step.
@@ -179,12 +179,15 @@ export const serve = <
       request,
       rawInitialPayload,
       qstashClient,
+      workflowUrl,
       workflowFailureUrl,
       debug
     );
     if (callReturnCheck.isErr()) {
       // error while checking
-      await debug?.log("ERROR", "SUBMIT_THIRD_PARTY_RESULT", { error: callReturnCheck.error });
+      await debug?.log("ERROR", "SUBMIT_THIRD_PARTY_RESULT", {
+        error: callReturnCheck.error.message,
+      });
       throw callReturnCheck.error;
     } else if (callReturnCheck.value === "continue-workflow") {
       // request is not third party call. Continue workflow as usual
@@ -199,7 +202,7 @@ export const serve = <
 
       if (result.isErr()) {
         // error while running the workflow or when cleaning up
-        await debug?.log("ERROR", "ERROR", { error: result.error });
+        await debug?.log("ERROR", "ERROR", { error: result.error.message });
         throw result.error;
       }
 

--- a/src/client/workflow/serve.ts
+++ b/src/client/workflow/serve.ts
@@ -17,14 +17,14 @@ import {
  * Fills the options with default values if they are not provided.
  *
  * Default values for:
- * - client: QStash client created with QSTASH_URL and QSTASH_TOKEN env vars
+ * - qstashClient: QStash client created with QSTASH_URL and QSTASH_TOKEN env vars
  * - onFinish: returns a Response with workflowRunId in the body and status: 200
  * - initialPayloadParser: calls JSON.parse if initial request body exists.
  *
  * @param options options including the client, onFinish and initialPayloadParser
  * @returns
  */
-const processOptions = <TResponse = Response, TInitialPayload = unknown>(
+const processOptions = <TResponse extends Response = Response, TInitialPayload = unknown>(
   options?: WorkflowServeOptions<TResponse, TInitialPayload>
 ): Required<WorkflowServeOptions<TResponse, TInitialPayload>> => {
   const receiverEnvironmentVariablesSet = Boolean(
@@ -85,7 +85,7 @@ const processOptions = <TResponse = Response, TInitialPayload = unknown>(
 export const serve = <
   TInitialPayload = unknown,
   TRequest extends Request = Request,
-  TResponse = Response,
+  TResponse extends Response = Response,
 >({
   routeFunction,
   options,

--- a/src/client/workflow/serve.ts
+++ b/src/client/workflow/serve.ts
@@ -32,7 +32,7 @@ const processOptions = <TResponse = Response, TInitialPayload = unknown>(
   );
 
   return {
-    client: new Client({
+    qstashClient: new Client({
       baseUrl: process.env.QSTASH_URL!,
       token: process.env.QSTASH_TOKEN!,
     }),
@@ -94,7 +94,7 @@ export const serve = <
 ) => Promise<TResponse>) => {
   // Prepares options with defaults if they are not provided.
   const {
-    client,
+    qstashClient,
     onStepFinish,
     initialPayloadParser,
     url,
@@ -148,7 +148,7 @@ export const serve = <
 
     // create context
     const workflowContext = new WorkflowContext<TInitialPayload>({
-      client,
+      qstashClient,
       workflowRunId,
       initialPayload: initialPayloadParser(rawInitialPayload),
       rawInitialPayload,
@@ -178,7 +178,7 @@ export const serve = <
     const callReturnCheck = await handleThirdPartyCallResult(
       request,
       rawInitialPayload,
-      client,
+      qstashClient,
       workflowFailureUrl,
       debug
     );

--- a/src/client/workflow/types.ts
+++ b/src/client/workflow/types.ts
@@ -82,9 +82,13 @@ export type RouteFunction<TInitialPayload> = (
   context: WorkflowContext<TInitialPayload>
 ) => Promise<void>;
 
-export type WorkflowServeParameters<TInitialPayload, TResponse extends Response = Response> = {
+export type WorkflowServeParameters<
+  TInitialPayload,
+  TResponse extends Response = Response,
+  TExcludeFromOptions extends keyof WorkflowServeOptions = never,
+> = {
   routeFunction: RouteFunction<TInitialPayload>;
-  options?: WorkflowServeOptions<TResponse, TInitialPayload>;
+  options?: Omit<WorkflowServeOptions<TResponse, TInitialPayload>, TExcludeFromOptions>;
 };
 
 /**
@@ -97,10 +101,14 @@ export type WorkflowServeParameters<TInitialPayload, TResponse extends Response 
 export type WorkflowServeParametersExtended<
   TInitialPayload = unknown,
   TResponse extends Response = Response,
-> = Pick<WorkflowServeParameters<TInitialPayload, TResponse>, "routeFunction"> & {
+  TExcludeFromOptions extends keyof WorkflowServeOptions = never,
+> = WorkflowServeParameters<
+  TInitialPayload,
+  TResponse,
+  "qstashClient" | "receiver" | TExcludeFromOptions
+> & {
   qstashClient: Client;
   receiver: WorkflowServeOptions["receiver"];
-  options?: Omit<WorkflowServeOptions<TResponse, TInitialPayload>, "qstashClient" | "receiver">;
 };
 
 export type FinishCondition =

--- a/src/client/workflow/types.ts
+++ b/src/client/workflow/types.ts
@@ -89,18 +89,18 @@ export type WorkflowServeParameters<TInitialPayload, TResponse = Response> = {
 
 /**
  * Not all frameworks use env variables like nextjs does. In this case, we need
- * to be able to get the client and receiver explicitly.
+ * to be able to get the qstashClient and receiver explicitly.
  *
  * In this case, we extend the WorkflowServeParameters by requiring an explicit
- * client & receiever parameters and removing client & receiever from options.
+ * qstashClient & receiever parameters and removing qstashClient & receiever from options.
  */
 export type WorkflowServeParametersExtended<TInitialPayload = unknown, TResponse = Response> = Pick<
   WorkflowServeParameters<TInitialPayload, TResponse>,
   "routeFunction"
 > & {
-  client: Client;
+  qstashClient: Client;
   receiver: WorkflowServeOptions["receiver"];
-  options?: Omit<WorkflowServeOptions<TResponse, TInitialPayload>, "client" | "receiver">;
+  options?: Omit<WorkflowServeOptions<TResponse, TInitialPayload>, "qstashClient" | "receiver">;
 };
 
 export type FinishCondition =
@@ -113,7 +113,7 @@ export type WorkflowServeOptions<TResponse = Response, TInitialPayload = unknown
   /**
    * QStash client
    */
-  client?: Client;
+  qstashClient?: Client;
   /**
    * Function called to return a response after each step execution
    *

--- a/src/client/workflow/types.ts
+++ b/src/client/workflow/types.ts
@@ -82,7 +82,7 @@ export type RouteFunction<TInitialPayload> = (
   context: WorkflowContext<TInitialPayload>
 ) => Promise<void>;
 
-export type WorkflowServeParameters<TInitialPayload, TResponse = Response> = {
+export type WorkflowServeParameters<TInitialPayload, TResponse extends Response = Response> = {
   routeFunction: RouteFunction<TInitialPayload>;
   options?: WorkflowServeOptions<TResponse, TInitialPayload>;
 };
@@ -94,10 +94,10 @@ export type WorkflowServeParameters<TInitialPayload, TResponse = Response> = {
  * In this case, we extend the WorkflowServeParameters by requiring an explicit
  * qstashClient & receiever parameters and removing qstashClient & receiever from options.
  */
-export type WorkflowServeParametersExtended<TInitialPayload = unknown, TResponse = Response> = Pick<
-  WorkflowServeParameters<TInitialPayload, TResponse>,
-  "routeFunction"
-> & {
+export type WorkflowServeParametersExtended<
+  TInitialPayload = unknown,
+  TResponse extends Response = Response,
+> = Pick<WorkflowServeParameters<TInitialPayload, TResponse>, "routeFunction"> & {
   qstashClient: Client;
   receiver: WorkflowServeOptions["receiver"];
   options?: Omit<WorkflowServeOptions<TResponse, TInitialPayload>, "qstashClient" | "receiver">;
@@ -109,7 +109,10 @@ export type FinishCondition =
   | "fromCallback"
   | "auth-fail"
   | "failure-callback";
-export type WorkflowServeOptions<TResponse = Response, TInitialPayload = unknown> = {
+export type WorkflowServeOptions<
+  TResponse extends Response = Response,
+  TInitialPayload = unknown,
+> = {
   /**
    * QStash client
    */
@@ -155,6 +158,17 @@ export type WorkflowServeOptions<TResponse = Response, TInitialPayload = unknown
    */
   failureUrl?: string | false;
   failureFunction?:
-    | ((status: number, header: Record<string, string>, body: string) => Promise<void>)
+    | ((
+        status: number,
+        header: Record<string, string>,
+        body: FailureFunctionPayload,
+        worklfowRunId: string
+      ) => Promise<void>)
     | false;
+};
+
+export type FailureFunctionPayload = {
+  error: string;
+  message: string;
+  stack?: string;
 };

--- a/src/client/workflow/workflow-requests.test.ts
+++ b/src/client/workflow/workflow-requests.test.ts
@@ -185,6 +185,7 @@ describe("Workflow Requests", () => {
             request,
             await request.text(),
             client,
+            WORKFLOW_ENDPOINT,
             WORKFLOW_ENDPOINT
           );
           expect(result.isOk());
@@ -248,6 +249,7 @@ describe("Workflow Requests", () => {
         request,
         await request.text(),
         client,
+        WORKFLOW_ENDPOINT,
         WORKFLOW_ENDPOINT
       );
       expect(result.isOk()).toBeTrue();
@@ -296,6 +298,7 @@ describe("Workflow Requests", () => {
         initialRequest,
         await initialRequest.text(),
         client,
+        WORKFLOW_ENDPOINT,
         WORKFLOW_ENDPOINT
       );
       expect(initialResult.isOk());
@@ -308,6 +311,7 @@ describe("Workflow Requests", () => {
         workflowRequest,
         await workflowRequest.text(),
         client,
+        WORKFLOW_ENDPOINT,
         WORKFLOW_ENDPOINT
       );
       expect(result.isOk()).toBeTrue();

--- a/src/client/workflow/workflow-requests.test.ts
+++ b/src/client/workflow/workflow-requests.test.ts
@@ -35,7 +35,7 @@ describe("Workflow Requests", () => {
     const token = "myToken";
 
     const context = new WorkflowContext({
-      client: new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token }),
+      qstashClient: new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token }),
       workflowRunId: workflowRunId,
       initialPayload,
       headers: new Headers({}) as Headers,
@@ -119,7 +119,7 @@ describe("Workflow Requests", () => {
     const token = "myToken";
 
     const context = new WorkflowContext({
-      client: new Client({ baseUrl: MOCK_SERVER_URL, token }),
+      qstashClient: new Client({ baseUrl: MOCK_SERVER_URL, token }),
       workflowRunId: workflowRunId,
       initialPayload: undefined,
       headers: new Headers({}) as Headers,
@@ -127,7 +127,7 @@ describe("Workflow Requests", () => {
       url: WORKFLOW_ENDPOINT,
     });
 
-    const spy = spyOn(context.client.http, "request");
+    const spy = spyOn(context.qstashClient.http, "request");
     await triggerWorkflowDelete(context);
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenLastCalledWith({

--- a/src/client/workflow/workflow-requests.test.ts
+++ b/src/client/workflow/workflow-requests.test.ts
@@ -45,7 +45,8 @@ describe("Workflow Requests", () => {
 
     await mockQstashServer({
       execute: async () => {
-        await triggerFirstInvocation(context);
+        const result = await triggerFirstInvocation(context);
+        expect(result.isOk()).toBeTrue();
       },
       responseFields: {
         body: { messageId: "msgId" },

--- a/src/client/workflow/workflow-requests.ts
+++ b/src/client/workflow/workflow-requests.ts
@@ -35,7 +35,7 @@ export const triggerFirstInvocation = async <TInitialPayload>(
     url: workflowContext.url,
   });
   return fromSafePromise(
-    workflowContext.client.publishJSON({
+    workflowContext.qstashClient.publishJSON({
       headers,
       method: "POST",
       body: workflowContext.requestPayload,
@@ -71,7 +71,7 @@ export const triggerWorkflowDelete = async <TInitialPayload>(
   await debug?.log("SUBMIT", "SUBMIT_CLEANUP", {
     deletedWorkflowRunId: workflowContext.workflowRunId,
   });
-  const result = await workflowContext.client.http.request({
+  const result = await workflowContext.qstashClient.http.request({
     path: ["v2", "workflows", "runs", `${workflowContext.workflowRunId}?cancel=${cancel}`],
     method: "DELETE",
     parseResponseAsJson: false,

--- a/src/client/workflow/workflow-requests.ts
+++ b/src/client/workflow/workflow-requests.ts
@@ -1,5 +1,5 @@
 import type { Err, Ok } from "neverthrow";
-import { err, fromSafePromise, ok } from "neverthrow";
+import { err, ok } from "neverthrow";
 import { QstashWorkflowAbort, QstashWorkflowError } from "../error";
 import type { WorkflowContext } from "./context";
 import type { Client } from "../client";
@@ -34,14 +34,17 @@ export const triggerFirstInvocation = async <TInitialPayload>(
     requestPayload: workflowContext.requestPayload,
     url: workflowContext.url,
   });
-  return fromSafePromise(
-    workflowContext.qstashClient.publishJSON({
+  try {
+    await workflowContext.qstashClient.publishJSON({
       headers,
       method: "POST",
       body: workflowContext.requestPayload,
       url: workflowContext.url,
-    })
-  );
+    });
+    return ok("success");
+  } catch (error) {
+    return err(error);
+  }
 };
 
 export const triggerRouteFunction = async ({


### PR DESCRIPTION
Should be reviewed & merged after #148.

- Makes `context.steps` private as we don't want the `Step` to be public.
- Renames `client` option in `serve` as `qstashClient` to make it more explicit
- Adds a method to cancel workflows `client.workflow.cancel(workflowRunId: string)` 
- Updates platform handlers to return a body when an error occurs in workflow
