### PR TITLE
Workflow: allow sync methods in context.run & failureFunction

### DIFF
--- a/src/client/workflow/auto-executor.test.ts
+++ b/src/client/workflow/auto-executor.test.ts
@@ -102,10 +102,9 @@ describe("auto-executor", () => {
       const spyRunParallel = spyOn(context.executor, "runParallel");
 
       await mockQStashServer({
-        // eslint-disable-next-line @typescript-eslint/require-await
-        execute: async () => {
-          const throws = context.run("attemptCharge", async () => {
-            return await Promise.resolve({ input: context.requestPayload, success: false });
+        execute: () => {
+          const throws = context.run("attemptCharge", () => {
+            return { input: context.requestPayload, success: false };
           });
           expect(throws).rejects.toThrowError(QStashWorkflowAbort);
         },
@@ -152,8 +151,8 @@ describe("auto-executor", () => {
         execute: async () => {
           expect(context.executor.stepCount).toBe(0);
           expect(context.executor.planStepCount).toBe(0);
-          const result = await context.run("attemptCharge", async () => {
-            return await Promise.resolve({ input: context.requestPayload, success: false });
+          const result = await context.run("attemptCharge", () => {
+            return { input: context.requestPayload, success: false };
           });
           expect(context.executor.stepCount).toBe(1);
           expect(context.executor.planStepCount).toBe(0);
@@ -183,8 +182,7 @@ describe("auto-executor", () => {
       const spyRunParallel = spyOn(context.executor, "runParallel");
 
       await mockQStashServer({
-        // eslint-disable-next-line @typescript-eslint/require-await
-        execute: async () => {
+        execute: () => {
           expect(context.executor.getParallelCallState(2, 1)).toBe("first");
           const throws = Promise.all([
             context.sleep("sleep for some time", 123),
@@ -249,8 +247,7 @@ describe("auto-executor", () => {
       const spyRunParallel = spyOn(context.executor, "runParallel");
 
       await mockQStashServer({
-        // eslint-disable-next-line @typescript-eslint/require-await
-        execute: async () => {
+        execute: () => {
           expect(context.executor.getParallelCallState(2, 1)).toBe("partial");
           const throws = Promise.all([
             context.sleep("sleep for some time", 123),
@@ -301,8 +298,7 @@ describe("auto-executor", () => {
       const spyRunParallel = spyOn(context.executor, "runParallel");
 
       await mockQStashServer({
-        // eslint-disable-next-line @typescript-eslint/require-await
-        execute: async () => {
+        execute: () => {
           expect(context.executor.getParallelCallState(2, 1)).toBe("partial");
           const throws = Promise.all([
             context.sleep("sleep for some time", 123),
@@ -353,8 +349,7 @@ describe("auto-executor", () => {
       const spyRunParallel = spyOn(context.executor, "runParallel");
 
       await mockQStashServer({
-        // eslint-disable-next-line @typescript-eslint/require-await
-        execute: async () => {
+        execute: () => {
           expect(context.executor.getParallelCallState(2, 1)).toBe("discard");
           const throws = Promise.all([
             context.sleep("sleep for some time", 123),
@@ -387,7 +382,6 @@ describe("auto-executor", () => {
       const spyRunParallel = spyOn(context.executor, "runParallel");
 
       await mockQStashServer({
-        // eslint-disable-next-line @typescript-eslint/require-await
         execute: async () => {
           expect(context.executor.getParallelCallState(2, 1)).toBe("last");
           expect(context.executor.stepCount).toBe(0);
@@ -425,8 +419,8 @@ describe("auto-executor", () => {
       test("step name", () => {
         const context = getContext([initialStep, singleStep]);
 
-        const throws = context.run("wrongName", async () => {
-          return await Promise.resolve(true);
+        const throws = context.run("wrongName", () => {
+          return true;
         });
         expect(throws).rejects.toThrow(
           new QStashWorkflowError(

--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -1,6 +1,6 @@
 import { QStashWorkflowAbort, QStashWorkflowError } from "../error";
 import type { WorkflowContext } from "./context";
-import type { AsyncStepFunction, ParallelCallState, Step } from "./types";
+import type { StepFunction, ParallelCallState, Step } from "./types";
 import { type BaseLazyStep } from "./steps";
 import { getHeaders } from "./workflow-requests";
 import type { WorkflowLogger } from "./logger";
@@ -93,10 +93,7 @@ export class AutoExecutor {
    * @param stepFunction step function to wrap
    * @returns wrapped step function
    */
-  public async wrapStep<TResult = unknown>(
-    stepName: string,
-    stepFunction: AsyncStepFunction<TResult>
-  ) {
+  public async wrapStep<TResult = unknown>(stepName: string, stepFunction: StepFunction<TResult>) {
     this.executingStep = stepName;
     const result = await stepFunction();
     this.executingStep = false;

--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -93,9 +93,12 @@ export class AutoExecutor {
    * @param stepFunction step function to wrap
    * @returns wrapped step function
    */
-  public async wrapStep<TResult = unknown>(stepName: string, stepFunction: StepFunction<TResult>) {
+  public wrapStep<TResult = unknown>(
+    stepName: string,
+    stepFunction: StepFunction<TResult>
+  ): TResult | Promise<TResult> {
     this.executingStep = stepName;
-    const result = await stepFunction();
+    const result = stepFunction();
     this.executingStep = false;
     return result;
   }

--- a/src/client/workflow/context.ts
+++ b/src/client/workflow/context.ts
@@ -205,7 +205,8 @@ export class WorkflowContext<TInitialPayload = unknown> {
     stepName: string,
     stepFunction: StepFunction<TResult>
   ): Promise<TResult> {
-    const wrappedStepFunction = async () => this.executor.wrapStep(stepName, stepFunction);
+    const wrappedStepFunction = (() =>
+      this.executor.wrapStep(stepName, stepFunction)) as StepFunction<TResult>;
     return this.addStep<TResult>(new LazyFunctionStep(stepName, wrappedStepFunction));
   }
 

--- a/src/client/workflow/context.ts
+++ b/src/client/workflow/context.ts
@@ -1,7 +1,7 @@
 import type { Err, Ok } from "neverthrow";
 import { err, ok } from "neverthrow";
 import type { RouteFunction, WorkflowClient } from "./types";
-import { type AsyncStepFunction, type Step } from "./types";
+import { type StepFunction, type Step } from "./types";
 import { AutoExecutor } from "./auto-executor";
 import type { BaseLazyStep } from "./steps";
 import { LazyCallStep, LazyFunctionStep, LazySleepStep, LazySleepUntilStep } from "./steps";
@@ -178,8 +178,8 @@ export class WorkflowContext<TInitialPayload = unknown> {
    * Executes a workflow step
    *
    * ```typescript
-   * const result = await context.run("step 1", async () => {
-   *   return await Promise.resolve("result")
+   * const result = await context.run("step 1", () => {
+   *   return "result"
    * })
    * ```
    *
@@ -188,11 +188,11 @@ export class WorkflowContext<TInitialPayload = unknown> {
    *
    * ```typescript
    * const [result1, result2] = await Promise.all([
-   *   context.run("step 1", async () => {
-   *     return await Promise.resolve("result1")
+   *   context.run("step 1", () => {
+   *     return "result1"
    *   })
    *   context.run("step 2", async () => {
-   *     return await Promise.resolve("result2")
+   *     return await fetchResults()
    *   })
    * ])
    * ```
@@ -203,7 +203,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
    */
   public async run<TResult>(
     stepName: string,
-    stepFunction: AsyncStepFunction<TResult>
+    stepFunction: StepFunction<TResult>
   ): Promise<TResult> {
     const wrappedStepFunction = async () => this.executor.wrapStep(stepName, stepFunction);
     return this.addStep<TResult>(new LazyFunctionStep(stepName, wrappedStepFunction));

--- a/src/client/workflow/integration.test.ts
+++ b/src/client/workflow/integration.test.ts
@@ -421,6 +421,42 @@ describe.skip("live serve tests", () => {
     }
   );
 
+  test(
+    "async/sync run methods",
+    async () => {
+      const finishState = new FinishState();
+      await testEndpoint({
+        finalCount: 5,
+        waitFor: 7000,
+        initialPayload: "my-payload",
+        finishState,
+        routeFunction: async (context) => {
+          const result1 = await context.run("async step", async () => {
+            return await Promise.resolve("result1");
+          });
+
+          expect(result1).toBe("result1");
+
+          const result2 = await context.run("sync step", () => {
+            return "result2";
+          });
+
+          expect(result2).toBe("result2");
+
+          const result3 = await context.run("sync step returning promise", () => {
+            return Promise.resolve("result3");
+          });
+
+          expect(result3).toBe("result3");
+          finishState.finish();
+        },
+      });
+    },
+    {
+      timeout: 10_000,
+    }
+  );
+
   // TODO: remove skip after adding a parameter to set step retries
   test.skip(
     "failureFunction",

--- a/src/client/workflow/integration.test.ts
+++ b/src/client/workflow/integration.test.ts
@@ -44,7 +44,6 @@
  * You may want to increase the `waitFor` and `timeout` parameters of the tests
  * because network takes some time.
  */
-/* eslint-disable @typescript-eslint/require-await */
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 /* eslint-disable prefer-const */
@@ -199,7 +198,7 @@ describe.skip("live serve tests", () => {
           const input = context.requestPayload;
           expect(input).toBeUndefined();
 
-          const result1 = await context.run("step1", async () => {
+          const result1 = await context.run("step1", () => {
             const output = 123;
             return output;
           });
@@ -207,7 +206,7 @@ describe.skip("live serve tests", () => {
 
           await context.sleepUntil("sleep1", Date.now() / 1000 + 3);
 
-          const result2 = await context.run("step2", async () => {
+          const result2 = await context.run("step2", () => {
             const output = 234;
             return output;
           });
@@ -215,7 +214,7 @@ describe.skip("live serve tests", () => {
 
           await context.sleep("sleep2", 2);
 
-          const result3 = await context.run("step3", async () => {
+          const result3 = await context.run("step3", () => {
             const output = 345;
             return output;
           });
@@ -244,7 +243,7 @@ describe.skip("live serve tests", () => {
           expect(invoice).toEqual(payload);
 
           for (let index = 0; index < 3; index++) {
-            const charge = await context.run("attemptCharge", async () => {
+            const charge = await context.run("attemptCharge", () => {
               const success = attemptCharge();
               const charge: Charge = { invoice, success };
               return charge;
@@ -252,10 +251,10 @@ describe.skip("live serve tests", () => {
 
             if (charge.success) {
               const [updateDb, receipt, sleepResult] = await Promise.all([
-                context.run("updateDb", async () => {
+                context.run("updateDb", () => {
                   return charge.invoice.amount;
                 }),
-                context.run("sendReceipt", async () => {
+                context.run("sendReceipt", () => {
                   return charge.invoice.email;
                 }),
                 context.sleep("sleep", 5),
@@ -268,7 +267,7 @@ describe.skip("live serve tests", () => {
             }
             await context.sleep("retrySleep", 2);
           }
-          await context.run("paymentFailed", async () => {
+          await context.run("paymentFailed", () => {
             return true;
           });
         },
@@ -298,15 +297,15 @@ describe.skip("live serve tests", () => {
 
           expect(input).toBe("my-payload");
 
-          const result1 = await context.run("step1", async () => {
-            return await Promise.resolve(someWork(input));
+          const result1 = await context.run("step1", () => {
+            return someWork(input);
           });
 
           expect(result1).toBe("processed 'my-payload'");
 
-          const result2 = await context.run("step2", async () => {
+          const result2 = await context.run("step2", () => {
             const result = someWork(result1);
-            return await Promise.resolve(result);
+            return result;
           });
 
           expect(result2).toBe("processed 'processed 'my-payload''");
@@ -328,6 +327,7 @@ describe.skip("live serve tests", () => {
         waitFor: 4500,
         initialPayload: "my-payload",
         finishState,
+        // eslint-disable-next-line @typescript-eslint/require-await
         routeFunction: async (context) => {
           if (context.headers.get("authentication") !== "Bearer aDifferentPassword") {
             console.error("Authentication failed.");
@@ -436,10 +436,11 @@ describe.skip("live serve tests", () => {
 
           expect(input).toBe("my-payload");
 
-          await context.run("step1", async () => {
+          await context.run("step1", () => {
             throw new Error("my-custom-error");
           });
         },
+        // eslint-disable-next-line @typescript-eslint/require-await
         failureFunction: async (context, failStatus, failResponse, failHeaders) => {
           expect(failStatus).toBe(500);
           expect(failResponse).toBe("my-custom-error");

--- a/src/client/workflow/integration.test.ts
+++ b/src/client/workflow/integration.test.ts
@@ -440,8 +440,7 @@ describe.skip("live serve tests", () => {
             throw new Error("my-custom-error");
           });
         },
-        // eslint-disable-next-line @typescript-eslint/require-await
-        failureFunction: async (context, failStatus, failResponse, failHeaders) => {
+        failureFunction: (context, failStatus, failResponse, failHeaders) => {
           expect(failStatus).toBe(500);
           expect(failResponse).toBe("my-custom-error");
           expect(context.headers.get("authentication")).toBe("Bearer secretPassword");

--- a/src/client/workflow/receiver.test.ts
+++ b/src/client/workflow/receiver.test.ts
@@ -47,8 +47,6 @@ async function createSignedRequest({
   key: string;
   headers?: Record<string, string>;
 }) {
-  // const base64body = btoa(body);
-
   const payload = {
     iss: "Upstash",
     sub: url,
@@ -88,8 +86,8 @@ const receiver = new Receiver({ currentSigningKey, nextSigningKey });
  */
 const endpoint = serve(
   async (context) => {
-    await context.run("step 1", async () => {
-      return await Promise.resolve("result");
+    await context.run("step 1", () => {
+      return "result";
     });
   },
   {
@@ -146,7 +144,6 @@ describe("receiver", () => {
       });
 
       await mockQStashServer({
-        // eslint-disable-next-line @typescript-eslint/require-await
         execute: async () => {
           const response = await endpoint(requestWithoutSignature);
           const body = (await response.json()) as FailureFunctionPayload;
@@ -169,7 +166,6 @@ describe("receiver", () => {
       });
 
       await mockQStashServer({
-        // eslint-disable-next-line @typescript-eslint/require-await
         execute: async () => {
           const response = await endpoint(requestWithoutSignature);
           const body = (await response.json()) as FailureFunctionPayload;
@@ -226,7 +222,6 @@ describe("receiver", () => {
       });
 
       await mockQStashServer({
-        // eslint-disable-next-line @typescript-eslint/require-await
         execute: async () => {
           const response = await endpoint(thirdPartyRequestWithoutHeader);
           const body = (await response.json()) as FailureFunctionPayload;
@@ -256,7 +251,6 @@ describe("receiver", () => {
       });
 
       await mockQStashServer({
-        // eslint-disable-next-line @typescript-eslint/require-await
         execute: async () => {
           const response = await endpoint(thirdPartyRequestWithoutHeader);
           const body = (await response.json()) as FailureFunctionPayload;
@@ -333,7 +327,6 @@ describe("receiver", () => {
       });
 
       await mockQStashServer({
-        // eslint-disable-next-line @typescript-eslint/require-await
         execute: async () => {
           const response = await endpoint(requestWithoutHeader);
           const body = (await response.json()) as FailureFunctionPayload;
@@ -357,7 +350,6 @@ describe("receiver", () => {
       });
 
       await mockQStashServer({
-        // eslint-disable-next-line @typescript-eslint/require-await
         execute: async () => {
           const response = await endpoint(requestWithoutHeader);
           const body = (await response.json()) as FailureFunctionPayload;

--- a/src/client/workflow/serve.test.ts
+++ b/src/client/workflow/serve.test.ts
@@ -237,14 +237,14 @@ describe("serve", () => {
   describe("duplicate checks", () => {
     const endpoint = serve(
       async (context) => {
-        const result1 = await context.run("step 1", async () => {
-          return await Promise.resolve("result 1");
+        const result1 = await context.run("step 1", () => {
+          return "result 1";
         });
-        const result2 = await context.run("step 2", async () => {
-          return await Promise.resolve("result 2");
+        const result2 = await context.run("step 2", () => {
+          return "result 2";
         });
-        await context.run("step 3", async () => {
-          return await Promise.resolve(`combined results: ${[result1, result2]}`);
+        await context.run("step 3", () => {
+          return `combined results: ${[result1, result2]}`;
         });
       },
       {

--- a/src/client/workflow/steps.test.ts
+++ b/src/client/workflow/steps.test.ts
@@ -12,9 +12,8 @@ describe("test steps", () => {
 
   describe("function step", () => {
     const result = nanoid();
-    // eslint-disable-next-line unicorn/consistent-function-scoping
-    const stepFunction = async () => {
-      return await Promise.resolve(result);
+    const stepFunction = () => {
+      return result;
     };
     const step = new LazyFunctionStep(stepName, stepFunction);
 

--- a/src/client/workflow/steps.ts
+++ b/src/client/workflow/steps.ts
@@ -60,7 +60,10 @@ export class LazyFunctionStep<TResult = unknown> extends BaseLazyStep<TResult> {
   }
 
   public async getResultStep(concurrent: number, stepId: number): Promise<Step<TResult>> {
-    const result = await this.stepFunction();
+    let result = this.stepFunction();
+    if (result instanceof Promise) {
+      result = await result;
+    }
 
     return {
       stepId,

--- a/src/client/workflow/steps.ts
+++ b/src/client/workflow/steps.ts
@@ -1,5 +1,5 @@
 import type { HTTPMethods } from "../types";
-import type { AsyncStepFunction, Step, StepType } from "./types";
+import type { Step, StepFunction, StepType } from "./types";
 
 /**
  * Base class outlining steps. Basically, each step kind (run/sleep/sleepUntil)
@@ -39,10 +39,10 @@ export abstract class BaseLazyStep<TResult = unknown> {
  * Lazy step definition for `context.run` case
  */
 export class LazyFunctionStep<TResult = unknown> extends BaseLazyStep<TResult> {
-  private readonly stepFunction: AsyncStepFunction<TResult>;
+  private readonly stepFunction: StepFunction<TResult>;
   stepType: StepType = "Run";
 
-  constructor(stepName: string, stepFunction: AsyncStepFunction<TResult>) {
+  constructor(stepName: string, stepFunction: StepFunction<TResult>) {
     super(stepName);
     this.stepFunction = stepFunction;
   }

--- a/src/client/workflow/test-utils.ts
+++ b/src/client/workflow/test-utils.ts
@@ -40,7 +40,7 @@ export const mockQStashServer = async ({
   responseFields,
   receivesRequest,
 }: {
-  execute: () => Promise<unknown>;
+  execute: () => unknown;
   responseFields: ResponseFields;
   receivesRequest: RequestFields | false;
 }) => {

--- a/src/client/workflow/types.ts
+++ b/src/client/workflow/types.ts
@@ -166,7 +166,7 @@ export type WorkflowServeOptions<
     failStatus: number,
     failResponse: string,
     failHeader: Record<string, string[]>
-  ) => Promise<void>;
+  ) => Promise<void> | void;
   /**
    * Base Url of the workflow endpoint
    *


### PR DESCRIPTION
It's now possible to pass a sync method in context.run
```javascript
const throws = context.run("attemptCharge", () => {
  return { input: context.requestPayload, success: false };
```

Also for failureFunction:
```javascript
failureFunction: (context, failStatus, failResponse, failHeaders) => {
  console.log("failure")
}
```