### PR TITLE
fix: allow params to be passed through Next.js App Router verify

### DIFF
--- a/platforms/nextjs.ts
+++ b/platforms/nextjs.ts
@@ -148,8 +148,8 @@ type VerifySignatureAppRouterResponse =
 
 export function verifySignatureAppRouter(
   handler:
-    | ((request: Request) => VerifySignatureAppRouterResponse)
-    | ((request: NextRequest) => VerifySignatureAppRouterResponse),
+    | ((request: Request, params?: unknown) => VerifySignatureAppRouterResponse)
+    | ((request: NextRequest, params?: unknown) => VerifySignatureAppRouterResponse),
   config?: VerifySignatureConfig
 ) {
   const currentSigningKey = config?.currentSigningKey ?? process.env.QSTASH_CURRENT_SIGNING_KEY;
@@ -169,7 +169,7 @@ export function verifySignatureAppRouter(
     nextSigningKey,
   });
 
-  return async (request: NextRequest | Request) => {
+  return async (request: NextRequest | Request, params?: unknown) => {
     const requestClone = request.clone() as NextRequest;
     const signature = request.headers.get("upstash-signature");
     if (!signature) {
@@ -191,7 +191,7 @@ export function verifySignatureAppRouter(
       return new NextResponse(new TextEncoder().encode("invalid signature"), { status: 403 });
     }
 
-    return handler(request as NextRequest);
+    return handler(request as NextRequest, params);
   };
 }
 


### PR DESCRIPTION
This PR modifies the [`verifySignatureAppRouter`](https://github.com/upstash/qstash-js/blob/5fb2171892fac72b1a3bb1be35745b5de2af0f4a/platforms/nextjs.ts#L149-L196) function for Next.js to account for [Dynamic Route Parameters](https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes).

At the moment, wrapping a function with `verifySignatureAppRouter` that resolves to `/api/webhook/[topic]/route.ts` will throw an error because the dynamic parameters are not passed through. The solution I'm proposing passes an optional `params` argument to the handler with type `unknown`.

This will work the both routes that have Dynamic Route Parameters and those that don't. Please let me know if there is anything else that would need to be covered in this PR.