### PR TITLE
Workflow: ignore cf-connecting-ip header for cf workers

### DIFF
--- a/src/client/workflow/workflow-requests.ts
+++ b/src/client/workflow/workflow-requests.ts
@@ -102,7 +102,8 @@ export const recreateUserHeaders = (headers: Headers): Headers => {
     if (
       !headerLowerCase.startsWith("upstash-workflow-") &&
       !headerLowerCase.startsWith("x-vercel-") &&
-      !headerLowerCase.startsWith("x-forwarded-")
+      !headerLowerCase.startsWith("x-forwarded-") &&
+      headerLowerCase !== "cf-connecting-ip"
     ) {
       filteredHeaders.append(header, value);
     }


### PR DESCRIPTION
if this header is forwarded, cf workers return 403 saying that the request was to an internal CF ip