### PR TITLE
Use atob instead of decodeBase64 in third party handler

### DIFF
--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -112,7 +112,7 @@ export function decodeBase64(base64: string) {
     // this error should never happen essentially. It's only a failsafe
     console.warn(
       `Upstash Qstash: Failed while decoding base64 "${base64}".` +
-        ` Decoding with atob and returning it instead. Error: ${error}`
+        ` Decoding with atob and returning it instead. ${error}`
     );
     return atob(base64);
   }
@@ -125,5 +125,4 @@ export function parseCursor(cursor: string) {
     timestamp: Number.parseInt(timestamp, 10),
     sequence: Number.parseInt(sequence, 10),
   };
-  
 }

--- a/src/client/workflow/integration.test.ts
+++ b/src/client/workflow/integration.test.ts
@@ -44,10 +44,9 @@
  * You may want to increase the `waitFor` and `timeout` parameters of the tests
  * because network takes some time.
  */
-/* eslint-disable no-console */
+
 /* eslint-disable @typescript-eslint/no-magic-numbers */
-/* eslint-disable prefer-const */
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+
 import { serve } from "bun";
 import { serve as workflowServe } from "../../../platforms/nextjs";
 import { expect, test, describe } from "bun:test";

--- a/src/client/workflow/workflow-requests.ts
+++ b/src/client/workflow/workflow-requests.ts
@@ -20,7 +20,6 @@ import type {
 } from "./types";
 import { StepTypes } from "./types";
 import type { WorkflowLogger } from "./logger";
-import { decodeBase64 } from "../utils";
 
 export const triggerFirstInvocation = async <TInitialPayload>(
   workflowContext: WorkflowContext<TInitialPayload>,
@@ -156,13 +155,13 @@ export const handleThirdPartyCallResult = async (
       if (!(callbackMessage.status >= 200 && callbackMessage.status < 300)) {
         await debug?.log("WARN", "SUBMIT_THIRD_PARTY_RESULT", {
           status: callbackMessage.status,
-          body: decodeBase64(callbackMessage.body),
+          body: atob(callbackMessage.body),
         });
         // this callback will be retried by the QStash, we just ignore it
         console.warn(
           `Workflow Warning: "context.call" failed with status ${callbackMessage.status}` +
             ` and will retry (if there are retries remaining).` +
-            ` Error Message:\n${decodeBase64(callbackMessage.body)}`
+            ` Error Message:\n${atob(callbackMessage.body)}`
         );
         return ok("call-will-retry");
       }
@@ -211,7 +210,7 @@ export const handleThirdPartyCallResult = async (
         stepId: Number(stepIdString),
         stepName,
         stepType,
-        out: decodeBase64(callbackMessage.body),
+        out: atob(callbackMessage.body),
         concurrent: Number(concurrentString),
       };
 


### PR DESCRIPTION
When context.call was used with an endpoint which returns binary (mp3 file), the binary was corrupted. Changing the decodeBase64 to atob in third party call handler fixes the issue.

The route which was used:

```ts
import {serve} from "@upstash/qstash/nextjs"
import fs from "fs";
import path from "path";

const ELEVENLABS_API_KEY = "***";
const ELEVENLABS_VOICE_ID = '***';


export const POST = serve(
    async (context) => {

        const voiceFile : any = await context.call(
            "transcribe-summary", // Step name
            `https://api.elevenlabs.io/v1/text-to-speech/${ELEVENLABS_VOICE_ID}`, // Endpoint URL
            "POST", // HTTP method
            { // Request body
                text: "this is a test",
                model_id: 'eleven_multilingual_v2',
                voice_settings: {
                    stability: 0.5,
                    similarity_boost: 0.5
                }
            },
            {
                'Accept': 'audio/mpeg',
                'xi-api-key': ELEVENLABS_API_KEY,
                'Content-Type': 'application/json',
            }
        );


      await context.run("save-audio", async () => {
          const fileName = `summary.mp3`;
          const filePath = path.join(__dirname, 'audio', fileName);

          // Ensure the audio directory exists
          fs.mkdirSync(path.join(__dirname, 'audio'), { recursive: true });

          // Ensure voiceFile is treated as binary data
          const buffer = Buffer.from(voiceFile, 'binary');

          // Save the MP3 file as binary
          fs.writeFileSync(filePath, buffer);
          console.log(`Audio file saved: ${filePath}`);
      })

    }
)
```