### PR TITLE
Add cp license and readme to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "upstash"
   ],
   "scripts": {
-    "build": "tsup && cp ./package.json ./dist",
+    "build": "tsup && cp README.md ./dist/ && cp package.json ./dist/ && cp LICENSE ./dist/",
     "test": "bun test src",
     "fmt": "prettier --write .",
     "lint": "tsc && eslint \"{src,platforms}/**/*.{js,ts,tsx}\"  --quiet --fix",


### PR DESCRIPTION
These cp statements were removed in #185. Adding them back because there is no text in npm https://www.npmjs.com/package/@upstash/qstash/v/2.7.11.