### PR TITLE
Add resend api

### DIFF
--- a/src/client/api/email.test.ts
+++ b/src/client/api/email.test.ts
@@ -46,4 +46,58 @@ describe("email", () => {
       },
     });
   });
+
+  test("should use resend with batch", async () => {
+    await mockQStashServer({
+      execute: async () => {
+        await client.publishJSON({
+          api: {
+            name: "email",
+            provider: resend({ token: resendToken, batch: true }),
+          },
+          body: [
+            {
+              from: "Acme <onboarding@resend.dev>",
+              to: ["foo@gmail.com"],
+              subject: "hello world",
+              html: "<h1>it works!</h1>",
+            },
+            {
+              from: "Acme <onboarding@resend.dev>",
+              to: ["bar@outlook.com"],
+              subject: "world hello",
+              html: "<p>it works!</p>",
+            },
+          ],
+        });
+      },
+      responseFields: {
+        body: { messageId: "msgId" },
+        status: 200,
+      },
+      receivesRequest: {
+        method: "POST",
+        token: qstashToken,
+        url: "http://localhost:8080/v2/publish/https://api.resend.com/emails/batch",
+        body: [
+          {
+            from: "Acme <onboarding@resend.dev>",
+            to: ["foo@gmail.com"],
+            subject: "hello world",
+            html: "<h1>it works!</h1>",
+          },
+          {
+            from: "Acme <onboarding@resend.dev>",
+            to: ["bar@outlook.com"],
+            subject: "world hello",
+            html: "<p>it works!</p>",
+          },
+        ],
+        headers: {
+          authorization: `Bearer ${qstashToken}`,
+          "upstash-forward-authorization": resendToken,
+        },
+      },
+    });
+  });
 });

--- a/src/client/api/email.test.ts
+++ b/src/client/api/email.test.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { describe, test } from "bun:test";
+import { Client } from "../client";
+import { resend } from "./email";
+
+describe("email", () => {
+  const client = new Client({ token: process.env.QSTASH_TOKEN! });
+
+  test("should use resend", async () => {
+    await client.publishJSON({
+      api: {
+        name: "email",
+        provider: resend({ token: process.env.RESEND_TOKEN! }),
+      },
+      body: {
+        from: "Acme <onboarding@resend.dev>",
+        to: ["delivered@resend.dev"],
+        subject: "hello world",
+        html: "<p>it works!</p>",
+      },
+    });
+  });
+});

--- a/src/client/api/email.test.ts
+++ b/src/client/api/email.test.ts
@@ -1,22 +1,48 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { describe, test } from "bun:test";
 import { Client } from "../client";
 import { resend } from "./email";
+import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "../workflow/test-utils";
+import { nanoid } from "../utils";
 
 describe("email", () => {
-  const client = new Client({ token: process.env.QSTASH_TOKEN! });
+  const qstashToken = nanoid();
+  const resendToken = nanoid();
+  const client = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token: qstashToken });
 
   test("should use resend", async () => {
-    await client.publishJSON({
-      api: {
-        name: "email",
-        provider: resend({ token: process.env.RESEND_TOKEN! }),
+    await mockQStashServer({
+      execute: async () => {
+        await client.publishJSON({
+          api: {
+            name: "email",
+            provider: resend({ token: resendToken }),
+          },
+          body: {
+            from: "Acme <onboarding@resend.dev>",
+            to: ["delivered@resend.dev"],
+            subject: "hello world",
+            html: "<p>it works!</p>",
+          },
+        });
       },
-      body: {
-        from: "Acme <onboarding@resend.dev>",
-        to: ["delivered@resend.dev"],
-        subject: "hello world",
-        html: "<p>it works!</p>",
+      responseFields: {
+        body: { messageId: "msgId" },
+        status: 200,
+      },
+      receivesRequest: {
+        method: "POST",
+        token: qstashToken,
+        url: "http://localhost:8080/v2/publish/https://api.resend.com/emails",
+        body: {
+          from: "Acme <onboarding@resend.dev>",
+          to: ["delivered@resend.dev"],
+          subject: "hello world",
+          html: "<p>it works!</p>",
+        },
+        headers: {
+          authorization: `Bearer ${qstashToken}`,
+          "upstash-forward-authorization": resendToken,
+        },
       },
     });
   });

--- a/src/client/api/email.ts
+++ b/src/client/api/email.ts
@@ -1,13 +1,19 @@
 export type EmailProviderReturnType = {
   owner: "resend";
-  baseUrl: "https://api.resend.com/emails";
+  baseUrl: "https://api.resend.com/emails" | "https://api.resend.com/emails/batch";
   token: string;
 };
 
-export const resend = ({ token }: { token: string }): EmailProviderReturnType => {
+export const resend = ({
+  token,
+  batch = false,
+}: {
+  token: string;
+  batch?: boolean;
+}): EmailProviderReturnType => {
   return {
     owner: "resend",
-    baseUrl: "https://api.resend.com/emails",
+    baseUrl: `https://api.resend.com/emails${batch ? "/batch" : ""}`,
     token,
   };
 };

--- a/src/client/api/email.ts
+++ b/src/client/api/email.ts
@@ -1,0 +1,13 @@
+export type EmailProviderReturnType = {
+  owner: "resend";
+  baseUrl: "https://api.resend.com/emails";
+  token: string;
+};
+
+export const resend = ({ token }: { token: string }): EmailProviderReturnType => {
+  return {
+    owner: "resend",
+    baseUrl: "https://api.resend.com/emails",
+    token,
+  };
+};

--- a/src/client/api/index.ts
+++ b/src/client/api/index.ts
@@ -1,7 +1,1 @@
-import type { PublishRequest } from "../client";
-
-export const appendAPIOptions = (request: PublishRequest<unknown>, headers: Headers) => {
-  if (request.api?.name === "email") {
-    headers.set("Authorization", request.api.provider.token);
-  }
-};
+export { resend } from "./email";

--- a/src/client/api/index.ts
+++ b/src/client/api/index.ts
@@ -1,0 +1,7 @@
+import type { PublishRequest } from "../client";
+
+export const appendAPIOptions = (request: PublishRequest<unknown>, headers: Headers) => {
+  if (request.api?.name === "email") {
+    headers.set("Authorization", request.api.provider.token);
+  }
+};

--- a/src/client/api/utils.ts
+++ b/src/client/api/utils.ts
@@ -1,0 +1,8 @@
+import type { PublishRequest } from "../client";
+
+export const appendAPIOptions = (request: PublishRequest<unknown>, headers: Headers) => {
+  if (request.api?.name === "email") {
+    headers.set("Authorization", request.api.provider.token);
+    request.method = request.method ?? "POST";
+  }
+};

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -453,6 +453,11 @@ export class Client {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       //@ts-ignore this is required otherwise message header prevent ts to compile
       appendLLMOptionsIfNeeded<TBody, TRequest>(message, message.headers, this.http);
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore this is required otherwise message header prevent ts to compile
+      appendAPIOptions(message, message.headers);
+
       (message.headers as Headers).set("Content-Type", "application/json");
     }
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,4 +1,4 @@
-import { appendAPIOptions } from "./api";
+import { appendAPIOptions } from "./api/utils";
 import type { EmailProviderReturnType } from "./api/email";
 import { DLQ } from "./dlq";
 import type { Duration } from "./duration";

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -181,7 +181,7 @@ export type PublishRequest<TBody = BodyInit> = {
       callback?: string;
     }
   | {
-      url?: never;
+      url?: string;
       urlGroup?: never;
       /**
        * The api endpoint the request should be sent to.
@@ -191,6 +191,7 @@ export type PublishRequest<TBody = BodyInit> = {
         provider?: ProviderReturnType;
         analytics?: { name: "helicone"; token: string };
       };
+      topic?: never;
       /**
        * Use a callback url to forward the response of your destination server to your callback url.
        *
@@ -198,7 +199,6 @@ export type PublishRequest<TBody = BodyInit> = {
        *
        * @default undefined
        */
-      topic?: never;
       callback: string;
     }
   | {

--- a/src/client/llm/utils.ts
+++ b/src/client/llm/utils.ts
@@ -8,7 +8,7 @@ export function appendLLMOptionsIfNeeded<
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   TRequest extends PublishRequest<TBody> = PublishRequest<TBody>,
 >(request: TRequest, headers: Headers, http: Requester) {
-  if (!request.api) return;
+  if (request.api?.name !== "llm") return;
 
   const provider = request.api.provider;
   const analytics = request.api.analytics;

--- a/src/client/llm/utils.ts
+++ b/src/client/llm/utils.ts
@@ -8,7 +8,7 @@ export function appendLLMOptionsIfNeeded<
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   TRequest extends PublishRequest<TBody> = PublishRequest<TBody>,
 >(request: TRequest, headers: Headers, http: Requester) {
-  if (request.api?.name !== "llm") return;
+  if (request.api?.name === "email" || !request.api) return;
 
   const provider = request.api.provider;
   const analytics = request.api.analytics;

--- a/src/client/queue.ts
+++ b/src/client/queue.ts
@@ -1,3 +1,4 @@
+import { appendAPIOptions } from "./api/utils";
 import type { PublishRequest, PublishResponse } from "./client";
 import type { Requester } from "./http";
 import { appendLLMOptionsIfNeeded, ensureCallbackPresent } from "./llm/utils";
@@ -139,6 +140,8 @@ export class Queue {
     ensureCallbackPresent<TBody>(request);
     // If needed, this allows users to directly pass their requests to any open-ai compatible 3rd party llm directly from sdk.
     appendLLMOptionsIfNeeded<TBody, TRequest>(request, headers, this.http);
+
+    appendAPIOptions(request, headers);
 
     const response = await this.enqueue({
       ...request,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,4 @@ export { decodeBase64 } from "./client/utils";
 export * from "./client/llm/chat";
 export * from "./client/llm/types";
 export * from "./client/llm/providers";
+export * from "./client/api";


### PR DESCRIPTION
adds resend api used like this:
```ts
await client.publishJSON({
  api: {
    name: "email",
    provider: resend({ token: process.env.RESEND_TOKEN! }),
  },
  body: {
    from: "Acme <onboarding@resend.dev>",
    to: ["delivered@resend.dev"],
    subject: "hello world",
    html: "<p>it works!</p>",
  },
});
```

body is not typesafe. Out llm api isn't typesafe too. It's not very simple to make it typesafe currently.

We can go ahead with this version and make it typesafe later