### PR TITLE
Proposal: Avoid using toSorted for compatibility with NodeJS 18

### DIFF
--- a/src/client/workflow/auto-executor.ts
+++ b/src/client/workflow/auto-executor.ts
@@ -484,5 +484,5 @@ const validateParallelSteps = (lazySteps: BaseLazyStep[], stepsFromRequest: Step
  */
 const sortSteps = (steps: Step[]): Step[] => {
   const getStepId = (step: Step) => step.targetStep ?? step.stepId;
-  return steps.toSorted((step, stepOther) => getStepId(step) - getStepId(stepOther));
+  return [...steps].sort((step, stepOther) => getStepId(step) - getStepId(stepOther));
 };


### PR DESCRIPTION
Should fix https://github.com/upstash/qstash-js/issues/209