### PR TITLE
Retry on ratelimit status

### DIFF
--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -36,7 +36,7 @@ describe("DLQ", () => {
 
       await sleep(10_000);
 
-      const dlqLogs = await client.dlq.listMessages();
+      const dlqLogs = await client.dlq.listMessages({ filter: { messageId: message.messageId } });
       expect(dlqLogs.messages.map((dlq) => dlq.messageId)).toContain(message.messageId);
     },
     { timeout: 20_000 }

--- a/src/client/error.ts
+++ b/src/client/error.ts
@@ -1,7 +1,7 @@
 import type { ChatRateLimit, RateLimit } from "./types";
 import type { FailureFunctionPayload, Step } from "./workflow/types";
 
-const RATELIMIT_STATUS = 429;
+export const RATELIMIT_STATUS = 429;
 
 /**
  * Result of 500 Internal Server Error

--- a/src/client/http.test.ts
+++ b/src/client/http.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, spyOn } from "bun:test";
 import { Client } from "./client";
+import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
 
 describe("http", () => {
   test("should terminate after sleeping 5 times", () => {
@@ -21,5 +22,54 @@ describe("http", () => {
 
     // if the Promise.race doesn't throw, that means the retries took longer than 4.5s
     expect(throws).toThrow("Was there a typo in the url or port?");
+  });
+
+  test.only("should backoff for seconds in ratelimit", async () => {
+    const qstashToken = "my-token";
+    const retries = 3;
+
+    const spy = spyOn(console, "warn");
+
+    let callCount = 0;
+    const client = new Client({
+      baseUrl: MOCK_QSTASH_SERVER_URL,
+      token: qstashToken,
+      retry: {
+        retries,
+        ratelimitBackoff: () => {
+          callCount += 1;
+          return 250;
+        },
+      },
+    });
+
+    await mockQStashServer({
+      execute: async () => {
+        await client.publishJSON({
+          url: "https://requestcatcher.com",
+        });
+        expect(callCount).toBe(retries);
+      },
+      receivesRequest: {
+        method: "POST",
+        token: qstashToken,
+        url: "http://localhost:8080/v2/publish/https://requestcatcher.com",
+      },
+      responseFields: {
+        status: 429,
+        headers: {
+          "Burst-RateLimit-Limit": "100",
+          "Burst-RateLimit-Remaining": "0",
+          "Burst-RateLimit-Reset": "213123",
+        },
+        body: "ratelimited",
+      },
+    });
+
+    expect(callCount).toBe(retries);
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenLastCalledWith(
+      'QStash Ratelimit Exceeded. Retrying after 250 milliseconds. Exceeded burst rate limit. {"limit":"100","remaining":"0","reset":"213123"}'
+    );
   });
 });

--- a/src/client/http.test.ts
+++ b/src/client/http.test.ts
@@ -24,7 +24,7 @@ describe("http", () => {
     expect(throws).toThrow("Was there a typo in the url or port?");
   });
 
-  test.only("should backoff for seconds in ratelimit", async () => {
+  test("should backoff for seconds in ratelimit", async () => {
     const qstashToken = "my-token";
     const retries = 3;
 

--- a/src/client/http.test.ts
+++ b/src/client/http.test.ts
@@ -27,28 +27,42 @@ describe("http", () => {
   test("should backoff for seconds in ratelimit", async () => {
     const qstashToken = "my-token";
     const retries = 3;
+    const retryDuration = 250;
 
     const spy = spyOn(console, "warn");
 
-    let callCount = 0;
+    let ratelimitBacoffCallCount = 0;
+    let backoffCallCount = 0;
     const client = new Client({
       baseUrl: MOCK_QSTASH_SERVER_URL,
       token: qstashToken,
       retry: {
         retries,
         ratelimitBackoff: () => {
-          callCount += 1;
-          return 250;
+          ratelimitBacoffCallCount += 1;
+          return retryDuration;
+        },
+        backoff: () => {
+          backoffCallCount += 1;
+          return 500;
         },
       },
     });
 
+    const throws = () =>
+      client.publishJSON({
+        url: "https://requestcatcher.com",
+      });
+
     await mockQStashServer({
-      execute: async () => {
-        await client.publishJSON({
-          url: "https://requestcatcher.com",
-        });
-        expect(callCount).toBe(retries);
+      execute: () => {
+        const start = Date.now();
+        expect(throws).toThrowError(
+          'Exceeded burst rate limit. {"limit":"100","remaining":"0","reset":"213123"}'
+        );
+        const duration = Date.now() - start;
+        const deviation = Math.abs(retryDuration * retries - duration);
+        expect(deviation).toBeLessThan(30);
       },
       receivesRequest: {
         method: "POST",
@@ -62,14 +76,65 @@ describe("http", () => {
           "Burst-RateLimit-Remaining": "0",
           "Burst-RateLimit-Reset": "213123",
         },
-        body: "ratelimited",
+        body: "sdf d",
       },
     });
 
-    expect(callCount).toBe(retries);
+    expect(ratelimitBacoffCallCount).toBe(retries);
+    expect(backoffCallCount).toBe(0);
     expect(spy).toHaveBeenCalledTimes(3);
     expect(spy).toHaveBeenLastCalledWith(
       'QStash Ratelimit Exceeded. Retrying after 250 milliseconds. Exceeded burst rate limit. {"limit":"100","remaining":"0","reset":"213123"}'
     );
+  });
+
+  test("should not retry on 400", async () => {
+    const qstashToken = "my-token";
+    const retries = 3;
+    const retryDuration = 250;
+
+    let ratelimitBacoffCallCount = 0;
+    let backoffCallCount = 0;
+    const client = new Client({
+      baseUrl: MOCK_QSTASH_SERVER_URL,
+      token: qstashToken,
+      retry: {
+        retries,
+        ratelimitBackoff: () => {
+          ratelimitBacoffCallCount += 1;
+          return retryDuration;
+        },
+        backoff: () => {
+          backoffCallCount += 1;
+          return 500;
+        },
+      },
+    });
+
+    const throws = () =>
+      client.publishJSON({
+        url: "https://requestcatcher.com",
+      });
+
+    await mockQStashServer({
+      execute: () => {
+        const start = Date.now();
+        expect(throws).toThrow("can't start with non https or http");
+        const duration = Date.now() - start;
+        expect(duration).toBeLessThan(30);
+      },
+      receivesRequest: {
+        method: "POST",
+        token: qstashToken,
+        url: "http://localhost:8080/v2/publish/https://requestcatcher.com",
+      },
+      responseFields: {
+        status: 400,
+        body: "can't start with non https or http",
+      },
+    });
+
+    expect(ratelimitBacoffCallCount).toBe(0);
+    expect(backoffCallCount).toBe(0);
   });
 });

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -70,7 +70,7 @@ export type RetryConfig =
       /**
        * A backoff function receives the current retry count and returns a number in milliseconds to wait before retrying.
        *
-       * Used when `fetch` throws an error, like
+       * Used when `fetch` throws an error
        *
        * @default
        * ```ts

--- a/src/client/workflow.test.ts
+++ b/src/client/workflow.test.ts
@@ -5,10 +5,9 @@ import { triggerFirstInvocation } from "./workflow/workflow-requests";
 import { WorkflowContext } from "./workflow/context";
 import { nanoid } from "nanoid";
 import { Client } from "./client";
-import { QstashError } from "./error";
 
 describe("workflow tests", () => {
-  const qstashClient = new Client({ token: process.env.QSTASH_TOKEN! });
+  const qstashClient = new Client({ token: process.env.QSTASH_TOKEN!, retry: false });
   test("should delete workflow succesfully", async () => {
     const workflowRunId = `wfr-${nanoid()}`;
     const result = await triggerFirstInvocation(
@@ -17,7 +16,7 @@ describe("workflow tests", () => {
         workflowRunId,
         headers: new Headers({}) as Headers,
         steps: [],
-        url: "https://some-url.com",
+        url: "https://requestcatcher.com",
         initialPayload: undefined,
       }),
       3
@@ -27,11 +26,5 @@ describe("workflow tests", () => {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     const cancelResult = await qstashClient.workflow.cancel(workflowRunId);
     expect(cancelResult).toBeTrue();
-
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const throws = qstashClient.workflow.cancel(workflowRunId);
-    expect(throws).rejects.toThrow(
-      new QstashError(`{"error":"workflowRun ${workflowRunId} not found"}`, 404)
-    );
   });
 });

--- a/src/client/workflow/test-utils.ts
+++ b/src/client/workflow/test-utils.ts
@@ -16,6 +16,7 @@ export const WORKFLOW_ENDPOINT = "https://www.my-website.com/api";
 export type ResponseFields = {
   body: unknown;
   status: number;
+  headers?: Record<string, string>;
 };
 
 export type RequestFields = {
@@ -84,6 +85,7 @@ export const mockQStashServer = async ({
       }
       return new Response(JSON.stringify(responseFields.body), {
         status: responseFields.status,
+        headers: responseFields.headers,
       });
     },
     port: MOCK_QSTASH_SERVER_PORT,


### PR DESCRIPTION
With this PR, we update the qstash-js client to retry ratelimit errors. The client will retry with this algorithm by default

```
((lastBackoff) => Math.max(lastBackoff, Math.random() * 4000) + 1000),
```

In a nutshell, it's the max of `last backoff + 1s` and `1-5s`. The aim is to spread the load over time while keeping the durations small.