### PR TITLE
DX-1614: Parallelism and Calls per second parameters

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -424,19 +424,19 @@ describe("flow control", () => {
     token,
   });
 
-  const rateLimitKey = nanoid();
+  const flowControlKey = nanoid();
 
   test("should throw if key is passed but no ratePerSec or parallelism", () => {
     // eslint-disable-next-line unicorn/consistent-function-scoping
     const throws = async () => {
       await client.publishJSON({
         url: "https://example.com/",
-        rateLimit: {
-          key: rateLimitKey,
+        flowControl: {
+          key: flowControlKey,
         },
       });
     };
-    expect(throws).toThrow("Provide at least one of parallelism or callsPerSecond for rateLimit");
+    expect(throws).toThrow("Provide at least one of parallelism or ratePerSecond for flowControl");
   });
 
   test("should publish a message with flow control", async () => {
@@ -444,10 +444,10 @@ describe("flow control", () => {
       execute: async () => {
         await client.publishJSON({
           urlGroup: "my-group",
-          rateLimit: {
-            key: rateLimitKey,
+          flowControl: {
+            key: flowControlKey,
             parallelism: 3,
-            callsPerSecond: 5,
+            ratePerSecond: 5,
           },
         });
       },
@@ -461,7 +461,7 @@ describe("flow control", () => {
         url: "http://localhost:8080/v2/publish/my-group",
         body: undefined,
         headers: {
-          "Upstash-Flow-Control-Key": rateLimitKey,
+          "Upstash-Flow-Control-Key": flowControlKey,
           "Upstash-Flow-Control-Value": "parallelism=3, rate=5",
         },
       },
@@ -469,23 +469,23 @@ describe("flow control", () => {
   });
 
   test("should batch messages with flow control", async () => {
-    const rateLimitKeyOne = nanoid();
-    const rateLimitKeyTwo = nanoid();
+    const flowControlKeyOne = nanoid();
+    const flowControlKeyTwo = nanoid();
     await mockQStashServer({
       execute: async () => {
         await client.batch([
           {
             url: "https://example.com/one",
-            rateLimit: {
-              key: rateLimitKeyOne,
-              callsPerSecond: 10,
+            flowControl: {
+              key: flowControlKeyOne,
+              ratePerSecond: 10,
             },
             body: "some-body",
           },
           {
             url: "https://example.com/two",
-            rateLimit: {
-              key: rateLimitKeyTwo,
+            flowControl: {
+              key: flowControlKeyTwo,
               parallelism: 5,
             },
             method: "GET",
@@ -505,7 +505,7 @@ describe("flow control", () => {
             body: "some-body",
             destination: "https://example.com/one",
             headers: {
-              "upstash-flow-control-key": rateLimitKeyOne,
+              "upstash-flow-control-key": flowControlKeyOne,
               "upstash-flow-control-value": "rate=10",
               "upstash-method": "POST",
             },
@@ -513,7 +513,7 @@ describe("flow control", () => {
           {
             destination: "https://example.com/two",
             headers: {
-              "upstash-flow-control-key": rateLimitKeyTwo,
+              "upstash-flow-control-key": flowControlKeyTwo,
               "upstash-flow-control-value": "parallelism=5",
               "upstash-method": "GET",
             },

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -436,7 +436,7 @@ describe("flow control", () => {
         },
       });
     };
-    expect(throws).toThrow("Provide at least one of parallelism or callsPerSec for rateLimit");
+    expect(throws).toThrow("Provide at least one of parallelism or callsPerSecond for rateLimit");
   });
 
   test("should publish a message with flow control", async () => {
@@ -447,7 +447,7 @@ describe("flow control", () => {
           rateLimit: {
             key: rateLimitKey,
             parallelism: 3,
-            callsPerSec: 5,
+            callsPerSecond: 5,
           },
         });
       },
@@ -478,7 +478,7 @@ describe("flow control", () => {
             url: "https://example.com/one",
             rateLimit: {
               key: rateLimitKeyOne,
-              callsPerSec: 10,
+              callsPerSecond: 10,
             },
             body: "some-body",
           },

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -431,6 +431,7 @@ describe("flow control", () => {
     const throws = async () => {
       await client.publishJSON({
         url: "https://example.com/",
+        // @ts-expect-error missing ratePerSecond or parallelism for test purposes
         flowControl: {
           key: flowControlKey,
         },

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -168,7 +168,7 @@ export type PublishRequest<TBody = BodyInit> = {
   /**
    * TODO
    */
-  rateLimit?: FlowControl;
+  flowControl?: FlowControl;
 } & (
   | {
       /**

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -5,7 +5,15 @@ import { Chat } from "./llm/chat";
 import { Messages } from "./messages";
 import { Queue } from "./queue";
 import { Schedules } from "./schedules";
-import type { BodyInit, Event, GetEventsPayload, HeadersInit, HTTPMethods, State } from "./types";
+import type {
+  BodyInit,
+  Event,
+  FlowControl,
+  GetEventsPayload,
+  HeadersInit,
+  HTTPMethods,
+  State,
+} from "./types";
 import { UrlGroups } from "./url-groups";
 import { getRequestPath, prefixHeaders, processHeaders, wrapWithGlobalHeaders } from "./utils";
 import { Workflow } from "./workflow";
@@ -156,6 +164,11 @@ export type PublishRequest<TBody = BodyInit> = {
    * @default undefined
    */
   timeout?: Duration | number;
+
+  /**
+   * TODO
+   */
+  rateLimit?: FlowControl;
 } & (
   | {
       /**

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -166,7 +166,8 @@ export type PublishRequest<TBody = BodyInit> = {
   timeout?: Duration | number;
 
   /**
-   * TODO
+   * Settings for controlling the number of active requests
+   * and number of requests per second with the same key.
    */
   flowControl?: FlowControl;
 } & (

--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -144,7 +144,7 @@ describe("DLQ", () => {
 
       expect(message.flowControlKey).toBe("flow-key");
       expect(message.parallelism).toBe(parallelism);
-      expect(message.rate).toBe(ratePerSecond);
+      expect(message.ratePerSecond).toBe(ratePerSecond);
     },
     {
       timeout: 10_000,

--- a/src/client/dlq.ts
+++ b/src/client/dlq.ts
@@ -128,6 +128,7 @@ export class DLQ {
         return {
           ...message,
           urlGroup: message.topicName,
+          ratePerSecond: "rate" in message ? (message.rate as number) : undefined,
         };
       }),
       cursor: messagesPayload.cursor,

--- a/src/client/llm/chat.test.ts
+++ b/src/client/llm/chat.test.ts
@@ -117,7 +117,7 @@ describe("Test QStash chat", () => {
     { timeout: 30_000, retry: 3 }
   );
 
-  test("should publish with llm api", async () => {
+  test.skip("should publish with llm api", async () => {
     const result = await client.publishJSON({
       api: { name: "llm", provider: upstash() },
       body: {
@@ -290,7 +290,7 @@ describe("Test QStash chat with third party LLMs", () => {
     { timeout: 30_000, retry: 3 }
   );
 
-  test("should publish with llm api", async () => {
+  test.skip("should publish with llm api", async () => {
     const result = await client.publishJSON({
       api: {
         name: "llm",
@@ -321,7 +321,7 @@ describe("Test QStash chat with third party LLMs", () => {
     expect(deliveredEvent).not.toBeUndefined();
   });
 
-  test("should publish with llm api", () => {
+  test("should not be able to without callback", () => {
     //@ts-expect-error We intentionally omit the callback to ensure the function fails as expected
     const resultPromise = client.publishJSON({
       api: {

--- a/src/client/messages.test.ts
+++ b/src/client/messages.test.ts
@@ -94,7 +94,7 @@ describe("Messages", () => {
     const parallelism = 10;
     const ratePerSecond = 5;
     const { messageId } = await client.publish({
-      url: "https://httpstat.us/200",
+      url: "https://httpstat.us/200?sleep=30000",
       body: "hello",
       flowControl: {
         key: "flow-key",
@@ -106,6 +106,6 @@ describe("Messages", () => {
     const message = await client.messages.get(messageId);
     expect(message.flowControlKey).toBe("flow-key");
     expect(message.parallelism).toBe(parallelism);
-    expect(message.rate).toBe(ratePerSecond);
+    expect(message.ratePerSecond).toBe(ratePerSecond);
   });
 });

--- a/src/client/messages.test.ts
+++ b/src/client/messages.test.ts
@@ -89,4 +89,23 @@ describe("Messages", () => {
     },
     { timeout: 20_000 }
   );
+
+  test("should create message with flow control", async () => {
+    const parallelism = 10;
+    const ratePerSecond = 5;
+    const { messageId } = await client.publish({
+      url: "https://httpstat.us/200",
+      body: "hello",
+      flowControl: {
+        key: "flow-key",
+        parallelism,
+        ratePerSecond,
+      },
+    });
+
+    const message = await client.messages.get(messageId);
+    expect(message.flowControlKey).toBe("flow-key");
+    expect(message.parallelism).toBe(parallelism);
+    expect(message.rate).toBe(ratePerSecond);
+  });
 });

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -104,10 +104,8 @@ export type Message = {
   parallelism?: number;
   /**
    * number of requests to activate per second with the same flow control key
-   *
-   * set through the ratePerSecond parameter in flowControl.
    */
-  rate?: number;
+  ratePerSecond?: number;
 };
 
 export type MessagePayload = Omit<Message, "urlGroup"> & { topicName: string };
@@ -130,6 +128,7 @@ export class Messages {
     const message: Message = {
       ...messagePayload,
       urlGroup: messagePayload.topicName,
+      ratePerSecond: "rate" in messagePayload ? (messagePayload.rate as number) : undefined,
     };
     return message;
   }

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -93,6 +93,21 @@ export type Message = {
    * IP address of the publisher of this message
    */
   callerIp?: string;
+
+  /**
+   * flow control key
+   */
+  flowControlKey: string;
+  /**
+   * number of requests which can be active with the same flow control key
+   */
+  parallelism?: number;
+  /**
+   * number of requests to activate per second with the same flow control key
+   *
+   * set through the ratePerSecond parameter in flowControl.
+   */
+  rate?: number;
 };
 
 export type MessagePayload = Omit<Message, "urlGroup"> & { topicName: string };

--- a/src/client/schedules.test.ts
+++ b/src/client/schedules.test.ts
@@ -218,4 +218,22 @@ describe("Schedules", () => {
       },
     });
   });
+
+  test("should create schedule with flow control", async () => {
+    const scheduleId = nanoid();
+    await client.schedules.create({
+      destination: "https://www.initial.com",
+      cron: "*/5 * * * *",
+      scheduleId,
+      body: "my-payload",
+      flowControl: {
+        key: "flow-key",
+        parallelism: 10,
+      },
+    });
+
+    const schedule = await client.schedules.get(scheduleId);
+
+    // TODO: assert schedule fields
+  });
 });

--- a/src/client/schedules.test.ts
+++ b/src/client/schedules.test.ts
@@ -238,6 +238,6 @@ describe("Schedules", () => {
     const schedule = await client.schedules.get(scheduleId);
     expect(schedule.flowControlKey).toBe("flow-key");
     expect(schedule.parallelism).toBe(parallelism);
-    expect(schedule.rate).toBe(ratePerSecond);
+    expect(schedule.ratePerSecond).toBe(ratePerSecond);
   });
 });

--- a/src/client/schedules.test.ts
+++ b/src/client/schedules.test.ts
@@ -220,6 +220,8 @@ describe("Schedules", () => {
   });
 
   test("should create schedule with flow control", async () => {
+    const parallelism = 10;
+    const ratePerSecond = 5;
     const scheduleId = nanoid();
     await client.schedules.create({
       destination: "https://www.initial.com",
@@ -228,12 +230,14 @@ describe("Schedules", () => {
       body: "my-payload",
       flowControl: {
         key: "flow-key",
-        parallelism: 10,
+        parallelism,
+        ratePerSecond,
       },
     });
 
     const schedule = await client.schedules.get(scheduleId);
-
-    // TODO: assert schedule fields
+    expect(schedule.flowControlKey).toBe("flow-key");
+    expect(schedule.parallelism).toBe(parallelism);
+    expect(schedule.rate).toBe(ratePerSecond);
   });
 });

--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -20,6 +20,9 @@ export type Schedule = {
   callerIp?: string;
   isPaused: boolean;
   queueName?: string;
+  flowControlKey?: string;
+  parallelism?: number;
+  rate?: number;
 };
 
 export type CreateScheduleRequest = {

--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -22,7 +22,7 @@ export type Schedule = {
   queueName?: string;
   flowControlKey?: string;
   parallelism?: number;
-  rate?: number;
+  ratePerSecond?: number;
 };
 
 export type CreateScheduleRequest = {
@@ -228,20 +228,30 @@ export class Schedules {
    * Get a schedule
    */
   public async get(scheduleId: string): Promise<Schedule> {
-    return await this.http.request<Schedule>({
+    const schedule = await this.http.request<Schedule>({
       method: "GET",
       path: ["v2", "schedules", scheduleId],
     });
+
+    if ("rate" in schedule) schedule.ratePerSecond = schedule.rate as number;
+
+    return schedule;
   }
 
   /**
    * List your schedules
    */
   public async list(): Promise<Schedule[]> {
-    return await this.http.request<Schedule[]>({
+    const schedules = await this.http.request<Schedule[]>({
       method: "GET",
       path: ["v2", "schedules"],
     });
+
+    for (const schedule of schedules) {
+      if ("rate" in schedule) schedule.ratePerSecond = schedule.rate as number;
+    }
+
+    return schedules;
   }
 
   /**

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -48,3 +48,18 @@ export type RateLimit = {
   remaining: string | null;
   reset: string | null;
 };
+
+export type FlowControl = {
+  /**
+   * flow control key
+   */
+  key: string;
+  /**
+   * number of requests which can be active with the same key
+   */
+  parallelism?: number;
+  /**
+   * number of requests to activate per second with the same key
+   */
+  callsPerSec?: number;
+};

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -55,11 +55,11 @@ export type FlowControl = {
    */
   key: string;
   /**
-   * number of requests which can be active with the same key
+   * number of requests which can be active with the same flow control key
    */
   parallelism?: number;
   /**
-   * number of requests to activate per second with the same key
+   * number of requests to activate per second with the same flow control key
    */
   ratePerSecond?: number;
 };

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -61,5 +61,5 @@ export type FlowControl = {
   /**
    * number of requests to activate per second with the same key
    */
-  callsPerSecond?: number;
+  ratePerSecond?: number;
 };

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -54,12 +54,25 @@ export type FlowControl = {
    * flow control key
    */
   key: string;
-  /**
-   * number of requests which can be active with the same flow control key
-   */
-  parallelism?: number;
-  /**
-   * number of requests to activate per second with the same flow control key
-   */
-  ratePerSecond?: number;
-};
+} & (
+  | {
+      /**
+       * number of requests which can be active with the same flow control key
+       */
+      parallelism: number;
+      /**
+       * number of requests to activate per second with the same flow control key
+       */
+      ratePerSecond?: number;
+    }
+  | {
+      /**
+       * number of requests which can be active with the same flow control key
+       */
+      parallelism?: number;
+      /**
+       * number of requests to activate per second with the same flow control key
+       */
+      ratePerSecond: number;
+    }
+);

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -61,5 +61,5 @@ export type FlowControl = {
   /**
    * number of requests to activate per second with the same key
    */
-  callsPerSec?: number;
+  callsPerSecond?: number;
 };

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -98,16 +98,14 @@ export function processHeaders(request: PublishRequest) {
     const controlValue = [
       parallelism ? `parallelism=${parallelism}` : undefined,
       rate ? `rate=${rate}` : undefined,
-    ]
-      .filter(Boolean)
-      .join(", ");
+    ].filter(Boolean);
 
-    if (controlValue === "") {
+    if (controlValue.length === 0) {
       throw new QstashError("Provide at least one of parallelism or callsPerSecond for rateLimit");
     }
 
     headers.set("Upstash-Flow-Control-Key", request.rateLimit.key);
-    headers.set("Upstash-Flow-Control-Value", controlValue);
+    headers.set("Upstash-Flow-Control-Value", controlValue.join(", "));
   }
 
   return headers;

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -93,7 +93,7 @@ export function processHeaders(request: PublishRequest) {
 
   if (request.rateLimit?.key) {
     const parallelism = request.rateLimit.parallelism?.toString();
-    const rate = request.rateLimit.callsPerSec?.toString();
+    const rate = request.rateLimit.callsPerSecond?.toString();
 
     const controlValue = [
       parallelism ? `parallelism=${parallelism}` : undefined,
@@ -103,7 +103,7 @@ export function processHeaders(request: PublishRequest) {
       .join(", ");
 
     if (controlValue === "") {
-      throw new QstashError("Provide at least one of parallelism or callsPerSec for rateLimit");
+      throw new QstashError("Provide at least one of parallelism or callsPerSecond for rateLimit");
     }
 
     headers.set("Upstash-Flow-Control-Key", request.rateLimit.key);

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -91,6 +91,25 @@ export function processHeaders(request: PublishRequest) {
     }
   }
 
+  if (request.rateLimit?.key) {
+    const parallelism = request.rateLimit.parallelism?.toString();
+    const rate = request.rateLimit.callsPerSec?.toString();
+
+    const controlValue = [
+      parallelism ? `parallelism=${parallelism}` : undefined,
+      rate ? `rate=${rate}` : undefined,
+    ]
+      .filter(Boolean)
+      .join(", ");
+
+    if (controlValue === "") {
+      throw new QstashError("Provide at least one of parallelism or callsPerSec for rateLimit");
+    }
+
+    headers.set("Upstash-Flow-Control-Key", request.rateLimit.key);
+    headers.set("Upstash-Flow-Control-Value", controlValue);
+  }
+
   return headers;
 }
 

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -91,9 +91,9 @@ export function processHeaders(request: PublishRequest) {
     }
   }
 
-  if (request.rateLimit?.key) {
-    const parallelism = request.rateLimit.parallelism?.toString();
-    const rate = request.rateLimit.callsPerSecond?.toString();
+  if (request.flowControl?.key) {
+    const parallelism = request.flowControl.parallelism?.toString();
+    const rate = request.flowControl.ratePerSecond?.toString();
 
     const controlValue = [
       parallelism ? `parallelism=${parallelism}` : undefined,
@@ -101,10 +101,10 @@ export function processHeaders(request: PublishRequest) {
     ].filter(Boolean);
 
     if (controlValue.length === 0) {
-      throw new QstashError("Provide at least one of parallelism or callsPerSecond for rateLimit");
+      throw new QstashError("Provide at least one of parallelism or ratePerSecond for flowControl");
     }
 
-    headers.set("Upstash-Flow-Control-Key", request.rateLimit.key);
+    headers.set("Upstash-Flow-Control-Key", request.flowControl.key);
     headers.set("Upstash-Flow-Control-Value", controlValue.join(", "));
   }
 


### PR DESCRIPTION
This PR adds the following parameters which allow controlling the message per second and parallelism:
```
await client.publishJSON({
  ...,
  flowControl: {
    key: "rateLimitKey",
    parallelism: 3,
    ratePerSecond: 5,
  },
});
```

`flowControl` is available for publish, batch and schedules. It's not available for queues.