### PR TITLE
DX-1714: rm NextFetchEvent from the handler

### DIFF
--- a/platforms/nextjs.ts
+++ b/platforms/nextjs.ts
@@ -115,7 +115,7 @@ export function verifySignatureEdge(
     nextSigningKey,
   });
 
-  return async (request: NextRequest, nfe: NextFetchEvent) => {
+  return async (request: NextRequest) => {
     // @ts-ignore This can throw errors during vercel build
     const requestClone = request.clone() as NextRequest;
     const signature = request.headers.get("upstash-signature");
@@ -138,7 +138,7 @@ export function verifySignatureEdge(
       return new Response(new TextEncoder().encode("invalid signature"), { status: 403 });
     }
 
-    return handler(request, nfe);
+    return handler(request);
   };
 }
 


### PR DESCRIPTION
after next 15, we started seeing this error when verifySignatureEdge is used: 'Type "NextFetchEvent" is not a valid type for the function's second argument'. Removing the NextFetchEvent parameter fixes the issue.

A similar fix was made to Hono https://github.com/honojs/hono/issues/3548.