### PR TITLE
feat: add telemetry support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,9 @@ jobs:
           bun-version: latest
 
       - name: Set package version
-        run: echo $(jq --arg v "${{ env.VERSION }}" '(.version) = $v' package.json) > package.json
+        run: |
+          echo $(jq --arg v "${{ env.VERSION }}" '(.version) = $v' package.json) > package.json
+          echo "export const VERSION='${{ env.VERSION }}'" > ./version.ts
 
       - name: Install Dependencies
         run: bun install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -251,6 +251,7 @@ jobs:
       - name: Set version
         run: |
           echo $(jq --arg v "${{ steps.version.outputs.version }}" '(.version) = $v' package.json) > package.json
+          echo "export const VERSION='${{ env.VERSION }}'" > ./version.ts
 
       - name: Install Dependencies
         run: bun install

--- a/README.md
+++ b/README.md
@@ -131,6 +131,25 @@ const result = await client.publishJSON({
 
 See [the documentation](https://docs.upstash.com/qstash) for details.
 
+## Telemetry
+
+This sdk sends anonymous telemetry headers to help us improve your experience.
+We collect the following:
+
+- SDK version
+- Platform (Cloudflare, AWS or Vercel)
+- Runtime version (node@18.x)
+
+You can opt out by setting the `UPSTASH_DISABLE_TELEMETRY` environment variable
+to any truthy value. Or setting `enableTelemetry: false` in the client options.
+
+```ts
+const client = new Client({
+  token: "<QSTASH_TOKEN>",
+  enableTelemetry: false,
+});
+```
+
 ## Contributing
 
 ### Setup

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -422,6 +422,7 @@ describe("flow control", () => {
   const client = new Client({
     baseUrl: MOCK_QSTASH_SERVER_URL,
     token,
+    enableTelemetry: false,
   });
 
   const flowControlKey = nanoid();

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -341,14 +341,18 @@ export class Client {
       ? false
       : config?.enableTelemetry ?? true;
 
+  // @ts-expect-error caches is not defined in the types
+    const isCloudflare = typeof caches !== "undefined" && "default" in caches;
     const telemetryHeaders: Record<string, string> = enableTelemetry
       ? {
           "Upstash-Telemetry-Sdk": `upstash-vector-js@${VERSION}`,
-          "Upstash-Telemetry-Platform": environment.VERCEL
-            ? "vercel"
-            : environment.AWS_REGION
-              ? "aws"
-              : "unknown",
+          "Upstash-Telemetry-Platform": isCloudflare
+            ? "cloudflare"
+            : environment.VERCEL
+              ? "vercel"
+              : environment.AWS_REGION
+                ? "aws"
+                : "unknown",
           "Upstash-Telemetry-Runtime": getRuntime(),
         }
       : {};

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -344,9 +344,9 @@ export class Client {
     const telemetryHeaders: Record<string, string> = enableTelemetry
       ? {
           "Upstash-Telemetry-Sdk": `upstash-vector-js@${VERSION}`,
-          "Upstash-Telemetry-Platform": process.env.VERCEL
+          "Upstash-Telemetry-Platform": environment.VERCEL
             ? "vercel"
-            : process.env.AWS_REGION
+            : environment.AWS_REGION
               ? "aws"
               : "unknown",
           "Upstash-Telemetry-Runtime": getRuntime(),

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -361,7 +361,7 @@ export class Client {
       headers: new Headers({
         ...telemetryHeaders,
         //@ts-expect-error caused by undici and bunjs type overlap
-        ...prefixHeaders(new Headers(config?.headers ?? {})),
+        ...Object.fromEntries(prefixHeaders(new Headers(config?.headers ?? {})).entries()),
       }),
     });
 

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -56,6 +56,7 @@ export type Requester = {
   request: <TResult = unknown>(request: UpstashRequest) => Promise<UpstashResponse<TResult>>;
   requestStream: (request: UpstashRequest) => AsyncIterable<ChatCompletionChunk>;
   headers?: Headers;
+  telemetryHeaders?: Headers;
 };
 
 export type RetryConfig =
@@ -83,6 +84,7 @@ export type HttpClientConfig = {
   authorization: string;
   retry?: RetryConfig;
   headers?: Headers;
+  telemetryHeaders?: Headers;
 };
 
 export class HttpClient implements Requester {
@@ -98,6 +100,7 @@ export class HttpClient implements Requester {
   };
 
   public readonly headers;
+  public readonly telemetryHeaders;
 
   public constructor(config: HttpClientConfig) {
     this.baseUrl = config.baseUrl.replace(/\/$/, "");
@@ -117,6 +120,7 @@ export class HttpClient implements Requester {
           };
 
     this.headers = config.headers;
+    this.telemetryHeaders = config.telemetryHeaders;
   }
 
   public async request<TResult>(request: UpstashRequest): Promise<UpstashResponse<TResult>> {

--- a/src/client/llm/chat.test.ts
+++ b/src/client/llm/chat.test.ts
@@ -407,6 +407,7 @@ describe("createThirdParty", () => {
     requestStream: mock((config: unknown) => {
       return config as AsyncIterable<ChatCompletionChunk>;
     }),
+    wrapWithGlobalHeaders: (headers: Headers) => headers,
   };
 
   client.http = mockHttp as Requester;

--- a/src/client/queue.ts
+++ b/src/client/queue.ts
@@ -115,7 +115,8 @@ export class Queue {
 
     const headers = wrapWithGlobalHeaders(
       processHeaders(request),
-      this.http.headers
+      this.http.headers,
+      this.http.telemetryHeaders
     ) as HeadersInit;
 
     const destination = getRequestPath(request);

--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -218,7 +218,7 @@ export class Schedules {
 
     return await this.http.request({
       method: "POST",
-      headers: wrapWithGlobalHeaders(headers, this.http.headers) as HeadersInit,
+      headers: wrapWithGlobalHeaders(headers, this.http.headers, this.http.telemetryHeaders),
       path: ["v2", "schedules", request.destination],
       body: request.body,
     });

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -23,7 +23,11 @@ export function prefixHeaders(headers: Headers) {
   return headers;
 }
 
-export function wrapWithGlobalHeaders(headers: Headers, globalHeaders?: Headers): Headers {
+export function wrapWithGlobalHeaders(
+  headers: Headers,
+  globalHeaders?: Headers,
+  telemetryHeaders?: Headers
+): Headers {
   if (!globalHeaders) {
     return headers;
   }
@@ -33,6 +37,13 @@ export function wrapWithGlobalHeaders(headers: Headers, globalHeaders?: Headers)
   // eslint-disable-next-line unicorn/no-array-for-each
   headers.forEach((value, key) => {
     finalHeaders.set(key, value);
+  });
+
+  // Stack telemetry headers
+  // eslint-disable-next-line unicorn/no-array-for-each
+  telemetryHeaders?.forEach((value, key) => {
+    if (!value) return;
+    finalHeaders.append(key, value);
   });
 
   //@ts-expect-error caused by undici and bunjs type overlap
@@ -190,5 +201,5 @@ export function getRuntime() {
   if (typeof EdgeRuntime === "string") return "edge-light";
   else if (typeof process === "object" && typeof process.version === "string")
     return `node@${process.version}`;
-  return "unknown";
+  return "";
 }

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -181,3 +181,11 @@ export function parseCursor(cursor: string) {
     sequence: Number.parseInt(sequence, 10),
   };
 }
+
+export function getRuntime() {
+  if (typeof process === "object" && typeof process.versions == "object" && process.versions.bun)
+    return `bun@${process.versions.bun}`;
+
+  // @ts-expect-error Silence compiler
+  return typeof EdgeRuntime === "string" ? "edge-light" : `node@${process.version}`;
+}

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -186,6 +186,9 @@ export function getRuntime() {
   if (typeof process === "object" && typeof process.versions == "object" && process.versions.bun)
     return `bun@${process.versions.bun}`;
 
-  // @ts-expect-error Silence compiler
-  return typeof EdgeRuntime === "string" ? "edge-light" : `node@${process.version}`;
+  // @ts-expect-error EdgeRuntime is not defined in the types
+  if (typeof EdgeRuntime === "string") return "edge-light";
+  else if (typeof process === "object" && typeof process.version === "string")
+    return `node@${process.version}`;
+  return "unknown";
 }

--- a/src/client/workflow/auto-executor.test.ts
+++ b/src/client/workflow/auto-executor.test.ts
@@ -85,7 +85,7 @@ describe("auto-executor", () => {
 
   const getContext = (steps: Step[]) => {
     return new SpyWorkflowContext({
-      qstashClient: new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token }),
+      qstashClient: new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token, enableTelemetry: false }),
       workflowRunId,
       initialPayload,
       headers: new Headers({}) as Headers,

--- a/src/client/workflow/context.test.ts
+++ b/src/client/workflow/context.test.ts
@@ -10,7 +10,11 @@ import type { RouteFunction } from "./types";
 
 describe("context tests", () => {
   const token = nanoid();
-  const qstashClient = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
+  const qstashClient = new Client({
+    baseUrl: MOCK_QSTASH_SERVER_URL,
+    token,
+    enableTelemetry: false,
+  });
   test("should raise when there are nested steps (with run)", () => {
     const context = new WorkflowContext({
       qstashClient,
@@ -150,7 +154,11 @@ describe("context tests", () => {
 
 describe("disabled workflow context", () => {
   const token = nanoid();
-  const qstashClient = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
+  const qstashClient = new Client({
+    baseUrl: MOCK_QSTASH_SERVER_URL,
+    token,
+    enableTelemetry: false,
+  });
   const disabledContext = new DisabledWorkflowContext({
     qstashClient,
     workflowRunId: "wfr-foo",

--- a/src/client/workflow/integration.test.ts
+++ b/src/client/workflow/integration.test.ts
@@ -97,6 +97,7 @@ const attemptCharge = () => {
 const qstashClient = new Client({
   baseUrl: process.env.MOCK_QSTASH_URL,
   token: process.env.MOCK_QSTASH_TOKEN ?? "",
+  enableTelemetry: false,
 });
 
 const testEndpoint = async <TInitialPayload = unknown>({

--- a/src/client/workflow/receiver.test.ts
+++ b/src/client/workflow/receiver.test.ts
@@ -78,7 +78,7 @@ const nextSigningKey = nanoid();
 const randomBody = btoa(nanoid());
 
 const token = nanoid();
-const qstashClient = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
+const qstashClient = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token, enableTelemetry: false });
 const receiver = new Receiver({ currentSigningKey, nextSigningKey });
 
 /**

--- a/src/client/workflow/serve.test.ts
+++ b/src/client/workflow/serve.test.ts
@@ -27,7 +27,7 @@ const someWork = (input: string) => {
 const workflowRunId = `wfr${nanoid()}`;
 const token = nanoid();
 
-const qstashClient = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
+const qstashClient = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token, enableTelemetry: false });
 
 describe("serve", () => {
   test("should send create workflow request in initial request", async () => {

--- a/src/client/workflow/test-utils.ts
+++ b/src/client/workflow/test-utils.ts
@@ -39,10 +39,12 @@ export const mockQStashServer = async ({
   execute,
   responseFields,
   receivesRequest,
+  validateRequest,
 }: {
   execute: () => unknown;
   responseFields: ResponseFields;
   receivesRequest: RequestFields | false;
+  validateRequest?: (request: Request) => void;
 }) => {
   const shouldBeCalled = Boolean(receivesRequest);
   let called = false;
@@ -74,6 +76,8 @@ export const mockQStashServer = async ({
             expect(request.headers.get(header)).toBe(value);
           }
         }
+
+        validateRequest?.(request);
       } catch (error) {
         if (error instanceof Error) {
           console.error("Assertion error:", error.message);

--- a/src/client/workflow/test-utils.ts
+++ b/src/client/workflow/test-utils.ts
@@ -80,7 +80,7 @@ export const mockQStashServer = async ({
         validateRequest?.(request);
       } catch (error) {
         if (error instanceof Error) {
-          console.error("Assertion error:", error.message);
+          console.error(error);
           return new Response(`assertion in mock QStash failed.`, {
             status: 400,
           });

--- a/version.ts
+++ b/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = "v0.0.0";


### PR DESCRIPTION
This PR adds support for telemetry. The client will send the following data:
- SDK version
- Platform (Cloudflare, AWS or Vercel)
- Runtime version (node@18.x)

These will be sent using headers in the form of `Upstash-Telemetry-*` with each request.

You can opt out by setting the `UPSTASH_DISABLE_TELEMETRY` environment variable
to any truthy value. Or setting `enableTelemetry: false` in the client options.

```sh
UPSTASH_DISABLE_TELEMETRY=1
```

or

```ts
const client = new Client({
  token: "<QSTASH_TOKEN>",
  enableTelemetry: false,
});
```