### PR TITLE
Warn against base url issues

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -5,6 +5,7 @@ import { nanoid } from "nanoid";
 import { Client } from "./client";
 import type { PublishToUrlResponse } from "../../dist";
 import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
+import type { HttpClient } from "./http";
 
 export const clearQueues = async (client: Client) => {
   const queueDetails = await client.queue().list();
@@ -626,5 +627,25 @@ describe("Telemetry headers", () => {
         expect(request.headers.get("Upstash-Telemetry-Platform")).toBe("aws");
       },
     });
+  });
+});
+
+describe("Client init", () => {
+  test("should use correct baseUrl if invalid one is passed", () => {
+    const client = new Client({
+      baseUrl: "https://qstash.upstash.io/v2/publish",
+      token: "some-token",
+    });
+
+    expect((client.http as HttpClient).baseUrl).toBe("https://qstash.upstash.io");
+  });
+
+  test("should use correct baseUrl if invalid one is passed", () => {
+    const client = new Client({
+      baseUrl: "https://qstash.upstash.io/v2/publish/",
+      token: "some-token",
+    });
+
+    expect((client.http as HttpClient).baseUrl).toBe("https://qstash.upstash.io");
   });
 });

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -338,6 +338,7 @@ export class Client {
       "https://qstash.upstash.io"
     ).replace(/\/$/, "");
 
+    // fixes https://github.com/upstash/qstash-js/issues/226
     if (baseUrl === "https://qstash.upstash.io/v2/publish") {
       baseUrl = "https://qstash.upstash.io";
     }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -332,9 +332,20 @@ export class Client {
     const environment =
       typeof process === "undefined" ? ({} as Record<string, string>) : process.env;
 
-    const baseUrl = config?.baseUrl
-      ? config.baseUrl.replace(/\/$/, "")
-      : environment.QSTASH_URL ?? "https://qstash.upstash.io";
+    let baseUrl = (
+      config?.baseUrl ??
+      environment.QSTASH_URL ??
+      "https://qstash.upstash.io"
+    ).replace(/\/$/, "");
+
+    if (baseUrl === "https://qstash.upstash.io/v2/publish") {
+      console.warn(
+        "[Upstash QStash] baseUrl is set to `https://qstash.upstash.io/v2/publish` which is not valid. `https://qstash.upstash.io` will be used instead. Please update your QSTASH_URL value from Upstash Console."
+      );
+
+      baseUrl = "https://qstash.upstash.io";
+    }
+
     const token = config?.token ?? environment.QSTASH_TOKEN;
 
     const enableTelemetry = environment.UPSTASH_DISABLE_TELEMETRY

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -339,10 +339,6 @@ export class Client {
     ).replace(/\/$/, "");
 
     if (baseUrl === "https://qstash.upstash.io/v2/publish") {
-      console.warn(
-        "[Upstash QStash] baseUrl is set to `https://qstash.upstash.io/v2/publish` which is not valid. `https://qstash.upstash.io` will be used instead. Please update your QSTASH_URL value from Upstash Console."
-      );
-
       baseUrl = "https://qstash.upstash.io";
     }
 


### PR DESCRIPTION
Added a warning and a fallback if QSTASH_URL or baseUrl is set to an incorrect value which seems common in users.

This is because the QSTASH_URL was probably incorrectly set in console or docs at some point.

Fixes https://github.com/upstash/qstash-js/issues/226