### PR TITLE
DX-1829: Add flow control period and deprecate ratePerSecond

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -536,7 +536,7 @@ describe("flow control", () => {
             destination: "https://example.com/three",
             headers: {
               "upstash-flow-control-key": flowControlKeyThree,
-              "upstash-flow-control-value": "parallelism=5, rate=5, period=1m",
+              "upstash-flow-control-value": "parallelism=5, rate=10, period=1m",
               "upstash-method": "PATCH",
             },
           },

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -474,6 +474,7 @@ describe("flow control", () => {
   test("should batch messages with flow control", async () => {
     const flowControlKeyOne = nanoid();
     const flowControlKeyTwo = nanoid();
+    const flowControlKeyThree = nanoid();
     await mockQStashServer({
       execute: async () => {
         await client.batch([
@@ -492,6 +493,16 @@ describe("flow control", () => {
               parallelism: 5,
             },
             method: "GET",
+          },
+          {
+            url: "https://example.com/three",
+            flowControl: {
+              key: flowControlKeyThree,
+              parallelism: 5,
+              rate: 10,
+              period: "1m",
+            },
+            method: "PATCH",
           },
         ]);
       },
@@ -519,6 +530,14 @@ describe("flow control", () => {
               "upstash-flow-control-key": flowControlKeyTwo,
               "upstash-flow-control-value": "parallelism=5",
               "upstash-method": "GET",
+            },
+          },
+          {
+            destination: "https://example.com/three",
+            headers: {
+              "upstash-flow-control-key": flowControlKeyThree,
+              "upstash-flow-control-value": "parallelism=5, rate=5, period=1m",
+              "upstash-method": "PATCH",
             },
           },
         ],

--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -1,8 +1,12 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-deprecated */
 import { sleep } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Client } from "./client";
+
+// Updated to use constants for magic numbers
+const SECONDS_IN_A_DAY = 24 * 60 * 60;
 
 describe("DLQ", () => {
   const client = new Client({ token: process.env.QSTASH_TOKEN! });
@@ -129,6 +133,7 @@ describe("DLQ", () => {
           key: "flow-key",
           parallelism,
           ratePerSecond,
+          period: "1d",
         },
       });
 
@@ -145,6 +150,8 @@ describe("DLQ", () => {
       expect(message.flowControlKey).toBe("flow-key");
       expect(message.parallelism).toBe(parallelism);
       expect(message.ratePerSecond).toBe(ratePerSecond);
+      expect(message.rate).toBe(ratePerSecond);
+      expect(message.period).toBe(SECONDS_IN_A_DAY);
     },
     {
       timeout: 10_000,

--- a/src/client/dlq.ts
+++ b/src/client/dlq.ts
@@ -128,7 +128,7 @@ export class DLQ {
         return {
           ...message,
           urlGroup: message.topicName,
-          ratePerSecond: "rate" in message ? (message.rate as number) : undefined,
+          ratePerSecond: "rate" in message ? message.rate : undefined,
         };
       }),
       cursor: messagesPayload.cursor,

--- a/src/client/messages.test.ts
+++ b/src/client/messages.test.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+/* eslint-disable @typescript-eslint/no-deprecated */
 import { beforeAll, describe, expect, test } from "bun:test";
 import { Client } from "./client";
+
+// Updated to use constants for magic numbers
+const SECONDS_IN_A_DAY = 24 * 60 * 60;
 
 describe("Messages", () => {
   const client = new Client({ token: process.env.QSTASH_TOKEN! });
@@ -93,6 +98,7 @@ describe("Messages", () => {
   test("should create message with flow control", async () => {
     const parallelism = 10;
     const ratePerSecond = 5;
+    const period = "1d";
     const { messageId } = await client.publish({
       url: "https://httpstat.us/200?sleep=30000",
       body: "hello",
@@ -100,12 +106,18 @@ describe("Messages", () => {
         key: "flow-key",
         parallelism,
         ratePerSecond,
+        period,
       },
     });
 
     const message = await client.messages.get(messageId);
+
     expect(message.flowControlKey).toBe("flow-key");
     expect(message.parallelism).toBe(parallelism);
     expect(message.ratePerSecond).toBe(ratePerSecond);
+    expect(message.rate).toBe(ratePerSecond);
+
+    const dayInSeconds = SECONDS_IN_A_DAY;
+    expect(message.period).toBe(dayInSeconds);
   });
 });

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -109,7 +109,8 @@ export type Message = {
    */
   ratePerSecond?: number;
   /**
-   * number of requests to activate per second with the same flow control key
+   * number of requests to activate within the period with the same flow control key.
+   * Default period is a second.
    */
   rate?: number;
   /**

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -104,8 +104,21 @@ export type Message = {
   parallelism?: number;
   /**
    * number of requests to activate per second with the same flow control key
+   *
+   * @deprecated use rate instead
    */
   ratePerSecond?: number;
+  /**
+   * number of requests to activate per second with the same flow control key
+   */
+  rate?: number;
+  /**
+   * The time interval during which the specified `rate` of requests can be activated
+   * using the same flow control key.
+   *
+   * In seconds.
+   */
+  period?: number;
 };
 
 export type MessagePayload = Omit<Message, "urlGroup"> & { topicName: string };
@@ -128,7 +141,7 @@ export class Messages {
     const message: Message = {
       ...messagePayload,
       urlGroup: messagePayload.topicName,
-      ratePerSecond: "rate" in messagePayload ? (messagePayload.rate as number) : undefined,
+      ratePerSecond: "rate" in messagePayload ? messagePayload.rate : undefined,
     };
     return message;
   }

--- a/src/client/schedules.test.ts
+++ b/src/client/schedules.test.ts
@@ -1,9 +1,14 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+/* eslint-disable @typescript-eslint/no-deprecated */
 import { afterEach, describe, expect, test } from "bun:test";
 import { Client } from "./client";
 import type { Schedule } from "./schedules";
 import { nanoid } from "nanoid";
 import { MOCK_QSTASH_SERVER_URL, MOCK_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
+
+// Updated to use constants for magic numbers
+const SECONDS_IN_A_DAY = 24 * 60 * 60;
 
 describe("Schedules", () => {
   const client = new Client({ token: process.env.QSTASH_TOKEN! });
@@ -222,6 +227,7 @@ describe("Schedules", () => {
   test("should create schedule with flow control", async () => {
     const parallelism = 10;
     const ratePerSecond = 5;
+    const period = "1d";
     const scheduleId = nanoid();
     await client.schedules.create({
       destination: "https://www.initial.com",
@@ -231,7 +237,8 @@ describe("Schedules", () => {
       flowControl: {
         key: "flow-key",
         parallelism,
-        ratePerSecond,
+        rate: ratePerSecond,
+        period,
       },
     });
 
@@ -239,5 +246,7 @@ describe("Schedules", () => {
     expect(schedule.flowControlKey).toBe("flow-key");
     expect(schedule.parallelism).toBe(parallelism);
     expect(schedule.ratePerSecond).toBe(ratePerSecond);
+    expect(schedule.rate).toBe(ratePerSecond);
+    expect(schedule.period).toBe(SECONDS_IN_A_DAY); // 1d in seconds
   });
 });

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -104,13 +104,14 @@ export type FlowControl = {
        */
       rate?: number;
       /**
-       * The time interval during which the specified `rate` of requests can be activated
-       * using the same flow control key.
+       * The time interval for the `rate` limit.
        *
-       * Defaults to one second.
+       * For example, if `rate` is 10 and `period` is "1s" (or 1), then 10 requests can be activated per second.
+       * If `rate` is 5 and `period` is "1m" (or 60), then 5 requests can be activated per minute.
        *
-       * If specified as a number, it is interpreted as seconds. Alternatively a duration string
-       * can be passed like "10s", "5d".
+       * Defaults to "1s" (one second) if not specified.
+       *
+       * Can be specified as a number (in seconds) or a duration string (e.g., "10s", "5m", "1h", "2d").
        */
       period?: Duration | number;
     }
@@ -131,13 +132,14 @@ export type FlowControl = {
        */
       rate?: number;
       /**
-       * The time interval during which the specified `rate` of requests can be activated
-       * using the same flow control key.
+       * The time interval for the `rate` limit.
        *
-       * Defaults to one second.
+       * For example, if `rate` is 10 and `period` is "1s" (or 1), then 10 requests can be activated per second.
+       * If `rate` is 5 and `period` is "1m" (or 60), then 5 requests can be activated per minute.
        *
-       * If specified as a number, it is interpreted as seconds. Alternatively a duration string
-       * can be passed like "10s", "5d".
+       * Defaults to "1s" (one second) if not specified.
+       *
+       * Can be specified as a number (in seconds) or a duration string (e.g., "10s", "5m", "1h", "2d").
        */
       period?: Duration | number;
     }
@@ -158,13 +160,14 @@ export type FlowControl = {
        */
       rate: number;
       /**
-       * The time interval during which the specified `rate` of requests can be activated
-       * using the same flow control key.
+       * The time interval for the `rate` limit.
        *
-       * Defaults to one second.
+       * For example, if `rate` is 10 and `period` is "1s" (or 1), then 10 requests can be activated per second.
+       * If `rate` is 5 and `period` is "1m" (or 60), then 5 requests can be activated per minute.
        *
-       * If specified as a number, it is interpreted as seconds. Alternatively a duration string
-       * can be passed like "10s", "5d".
+       * Defaults to "1s" (one second) if not specified.
+       *
+       * Can be specified as a number (in seconds) or a duration string (e.g., "10s", "5m", "1h", "2d").
        */
       period?: Duration | number;
     }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,3 +1,5 @@
+import type { Duration } from "./duration";
+
 export type State =
   | "CREATED"
   | "ACTIVE"
@@ -91,8 +93,26 @@ export type FlowControl = {
       parallelism: number;
       /**
        * number of requests to activate per second with the same flow control key
+       *
+       * @deprecated use rate instead
        */
       ratePerSecond?: number;
+      /**
+       * number of requests to activate within the period with the same flow control key.
+       *
+       * Default period is a second.
+       */
+      rate?: number;
+      /**
+       * The time interval during which the specified `rate` of requests can be activated
+       * using the same flow control key.
+       *
+       * Defaults to one second.
+       *
+       * If specified as a number, it is interpreted as seconds. Alternatively a duration string
+       * can be passed like "10s", "5d".
+       */
+      period?: Duration | number;
     }
   | {
       /**
@@ -101,7 +121,51 @@ export type FlowControl = {
       parallelism?: number;
       /**
        * number of requests to activate per second with the same flow control key
+       *
+       * @deprecated use rate instead
        */
       ratePerSecond: number;
+      /**
+       * number of requests to activate within the period with the same flow control key.
+       * Default period is a second.
+       */
+      rate?: number;
+      /**
+       * The time interval during which the specified `rate` of requests can be activated
+       * using the same flow control key.
+       *
+       * Defaults to one second.
+       *
+       * If specified as a number, it is interpreted as seconds. Alternatively a duration string
+       * can be passed like "10s", "5d".
+       */
+      period?: Duration | number;
+    }
+  | {
+      /**
+       * number of requests which can be active with the same flow control key
+       */
+      parallelism?: number;
+      /**
+       * number of requests to activate per second with the same flow control key
+       *
+       * @deprecated use rate instead
+       */
+      ratePerSecond?: number;
+      /**
+       * number of requests to activate within the period with the same flow control key.
+       * Default period is a second.
+       */
+      rate: number;
+      /**
+       * The time interval during which the specified `rate` of requests can be activated
+       * using the same flow control key.
+       *
+       * Defaults to one second.
+       *
+       * If specified as a number, it is interpreted as seconds. Alternatively a duration string
+       * can be passed like "10s", "5d".
+       */
+      period?: Duration | number;
     }
 );

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-deprecated */
 import { getProviderInfo } from "./api/utils";
 import type { PublishRequest } from "./client";
 import { QstashError } from "./error";
@@ -104,11 +105,16 @@ export function processHeaders(request: PublishRequest) {
 
   if (request.flowControl?.key) {
     const parallelism = request.flowControl.parallelism?.toString();
-    const rate = request.flowControl.ratePerSecond?.toString();
+    const rate = (request.flowControl.rate ?? request.flowControl.ratePerSecond)?.toString();
+    const period =
+      typeof request.flowControl.period === "number"
+        ? `${request.flowControl.period}s`
+        : request.flowControl.period;
 
     const controlValue = [
       parallelism ? `parallelism=${parallelism}` : undefined,
       rate ? `rate=${rate}` : undefined,
+      period ? `period=${period}` : undefined,
     ].filter(Boolean);
 
     if (controlValue.length === 0) {


### PR DESCRIPTION
Adds period field to the flow control options and deprecates ratePerSecond in favor of rate:

```ts
const { messageId } = await client.publish({
  url: "https://some-url.com",
  flowControl: {
    key: "flow-key",
    rate: 10,
    period: "1d",
  },
});
```