### PR TITLE
QSTH-665: add retryDelay parameter & header

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Setup nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/src/client/api/email.test.ts
+++ b/src/client/api/email.test.ts
@@ -257,7 +257,7 @@ describe("email", () => {
           [`upstash-forward-${requestHeader}`]: requestHeaderValue,
           [`upstash-forward-${globalHeader}`]: globalHeaderValue,
           [`upstash-forward-${globalHeaderOverwritten}`]: overWrittenNewValue,
-          "upstash-retry-after": "pow(retried, 2) * 1000",
+          "upstash-retry-delay": "pow(retried, 2) * 1000",
         },
       },
     });

--- a/src/client/api/email.test.ts
+++ b/src/client/api/email.test.ts
@@ -219,6 +219,7 @@ describe("email", () => {
               html: "<p>it works!</p>",
             },
           ],
+          retryDelay: "pow(retried, 2) * 1000",
           headers: {
             "content-type": "application/json",
             [globalHeaderOverwritten]: overWrittenNewValue,
@@ -256,6 +257,7 @@ describe("email", () => {
           [`upstash-forward-${requestHeader}`]: requestHeaderValue,
           [`upstash-forward-${globalHeader}`]: globalHeaderValue,
           [`upstash-forward-${globalHeaderOverwritten}`]: overWrittenNewValue,
+          "upstash-retry-after": "pow(retried, 2) * 1000",
         },
       },
     });

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -452,6 +452,7 @@ describe("flow control", () => {
             parallelism: 3,
             ratePerSecond: 5,
           },
+          retryDelay: "pow(retried, 2) * 1000",
         });
       },
       responseFields: {
@@ -466,6 +467,7 @@ describe("flow control", () => {
         headers: {
           "Upstash-Flow-Control-Key": flowControlKey,
           "Upstash-Flow-Control-Value": "parallelism=3, rate=5",
+          "upstash-retry-after": "pow(retried, 2) * 1000",
         },
       },
     });
@@ -485,6 +487,7 @@ describe("flow control", () => {
               ratePerSecond: 10,
             },
             body: "some-body",
+            retryDelay: "pow(retried, 2) * 1000",
           },
           {
             url: "https://example.com/two",
@@ -522,6 +525,7 @@ describe("flow control", () => {
               "upstash-flow-control-key": flowControlKeyOne,
               "upstash-flow-control-value": "rate=10",
               "upstash-method": "POST",
+              "upstash-retry-after": "pow(retried, 2) * 1000",
             },
           },
           {

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -467,7 +467,7 @@ describe("flow control", () => {
         headers: {
           "Upstash-Flow-Control-Key": flowControlKey,
           "Upstash-Flow-Control-Value": "parallelism=3, rate=5",
-          "upstash-retry-after": "pow(retried, 2) * 1000",
+          "upstash-retry-delay": "pow(retried, 2) * 1000",
         },
       },
     });
@@ -525,7 +525,7 @@ describe("flow control", () => {
               "upstash-flow-control-key": flowControlKeyOne,
               "upstash-flow-control-value": "rate=10",
               "upstash-method": "POST",
-              "upstash-retry-after": "pow(retried, 2) * 1000",
+              "upstash-retry-delay": "pow(retried, 2) * 1000",
             },
           },
           {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -153,6 +153,37 @@ export type PublishRequest<TBody = BodyInit> = {
   retries?: number;
 
   /**
+   * Delay between retries.
+   *
+   * By default, the `retryDelay` is exponential backoff. More details can be found in
+   * For more details and advanced usage, see: https://upstash.com/docs/qstash/features/retry.
+   *
+   * The `retryDelay` option allows you to customize the delay (in milliseconds) between retry attempts when message delivery fails.
+   *
+   * You can use mathematical expressions and the following built-in functions to calculate the delay dynamically. The special variable `retried` represents the current retry attempt count (starting from 1).
+   *
+   * Supported functions:
+   * - `pow`
+   * - `sqrt`
+   * - `abs`
+   * - `exp`
+   * - `floor`
+   * - `ceil`
+   * - `round`
+   * - `min`
+   * - `max`
+   *
+   * Examples of valid `retryDelay` values:
+   * ```ts
+   * 1000 // 1 second
+   * 1000 * retried  // 1 second multiplied by the current retry attempt
+   * pow(2, retried) // 2 to the power of the current retry attempt
+   * max(10, pow(2, retried)) // The greater of 10 or 2^retried
+   * ```
+   */
+  retryDelay?: string;
+
+  /**
    * Use a failure callback url to handle messages that could not be delivered.
    *
    * The failure callback url must be publicly accessible

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -155,12 +155,13 @@ export type PublishRequest<TBody = BodyInit> = {
   /**
    * Delay between retries.
    *
-   * By default, the `retryDelay` is exponential backoff. More details can be found in
-   * For more details and advanced usage, see: https://upstash.com/docs/qstash/features/retry.
+   * By default, the `retryDelay` is exponential backoff.
+   * More details can be found in: https://upstash.com/docs/qstash/features/retry.
    *
    * The `retryDelay` option allows you to customize the delay (in milliseconds) between retry attempts when message delivery fails.
    *
-   * You can use mathematical expressions and the following built-in functions to calculate the delay dynamically. The special variable `retried` represents the current retry attempt count (starting from 1).
+   * You can use mathematical expressions and the following built-in functions to calculate the delay dynamically.
+   * The special variable `retried` represents the current retry attempt count (starting from 0).
    *
    * Supported functions:
    * - `pow`
@@ -176,7 +177,7 @@ export type PublishRequest<TBody = BodyInit> = {
    * Examples of valid `retryDelay` values:
    * ```ts
    * 1000 // 1 second
-   * 1000 * retried  // 1 second multiplied by the current retry attempt
+   * 1000 * (1 + retried)  // 1 second multiplied by the current retry attempt
    * pow(2, retried) // 2 to the power of the current retry attempt
    * max(10, pow(2, retried)) // The greater of 10 or 2^retried
    * ```

--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -125,6 +125,7 @@ describe("DLQ", () => {
     async () => {
       const parallelism = 10;
       const ratePerSecond = 5;
+      const retryDelay = "2000 * retried";
       const { messageId } = await client.publish({
         url: "https://httpstat.us/400",
         body: "hello",
@@ -135,6 +136,7 @@ describe("DLQ", () => {
           ratePerSecond,
           period: "1d",
         },
+        retryDelay,
       });
 
       await sleep(5000);
@@ -152,6 +154,7 @@ describe("DLQ", () => {
       expect(message.ratePerSecond).toBe(ratePerSecond);
       expect(message.rate).toBe(ratePerSecond);
       expect(message.period).toBe(SECONDS_IN_A_DAY);
+      expect(message.retryDelayExpression).toBe(retryDelay);
     },
     {
       timeout: 10_000,

--- a/src/client/messages.test.ts
+++ b/src/client/messages.test.ts
@@ -17,6 +17,7 @@ describe("Messages", () => {
   test(
     "should send message, cancel it then verify cancel",
     async () => {
+      const retryDelay = "1000 * retried";
       const message = await client.publishJSON({
         url: `https://example.com`,
         body: { hello: "world" },
@@ -29,10 +30,12 @@ describe("Messages", () => {
         callback: "https://example.com?foo=bar",
         failureCallback: "https://example.com?bar=baz",
         method: "GET",
+        retryDelay,
       });
 
       const verifiedMessage = await client.messages.get(message.messageId);
       expect(new Headers(verifiedMessage.header).get("Test-Header")).toBe("test-value");
+      expect(verifiedMessage.retryDelayExpression).toBe(retryDelay);
       await client.messages.delete(message.messageId);
     },
     { timeout: 20_000 }
@@ -78,7 +81,6 @@ describe("Messages", () => {
         },
       ]);
 
-      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expect(messages.length).toBe(3);
 
       const deleted = await client.messages.deleteMany([
@@ -86,7 +88,6 @@ describe("Messages", () => {
         messages[1].messageId,
       ]);
 
-      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expect(deleted).toBe(2);
 
       const deletedAll = await client.messages.deleteAll();

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -60,6 +60,10 @@ export type Message = {
    */
   maxRetries?: number;
 
+  /**
+   * The retry delay expression for this message,
+   * if retry_delay was set when publishing the message.
+   */
   retryDelayExpression?: PublishRequest["retryDelay"];
 
   /**

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -1,3 +1,4 @@
+import type { PublishRequest } from "../../dist";
 import type { Requester } from "./http";
 import type { HTTPMethods } from "./types";
 
@@ -58,6 +59,8 @@ export type Message = {
    * Maxmimum number of retries.
    */
   maxRetries?: number;
+
+  retryDelayExpression?: PublishRequest["retryDelay"];
 
   /**
    * A unix timestamp (milliseconds) after which this message may get delivered.

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -1,4 +1,4 @@
-import type { PublishRequest } from "../../dist";
+import type { PublishRequest } from "./client";
 import type { Requester } from "./http";
 import type { HTTPMethods } from "./types";
 

--- a/src/client/schedules.test.ts
+++ b/src/client/schedules.test.ts
@@ -224,7 +224,7 @@ describe("Schedules", () => {
           "upstash-cron": "* * * * 1",
           "upstash-retries": "3",
           "upstash-schedule-id": "asd",
-          "upstash-retry-after": "pow(retried, 2) * 1000",
+          "upstash-retry-delay": "pow(retried, 2) * 1000",
         },
       },
     });
@@ -235,6 +235,7 @@ describe("Schedules", () => {
     const ratePerSecond = 5;
     const period = "1d";
     const scheduleId = nanoid();
+    const retryDelay = "pow(retried, 2) * 1000";
     await client.schedules.create({
       destination: "https://www.initial.com",
       cron: "*/5 * * * *",
@@ -246,13 +247,16 @@ describe("Schedules", () => {
         rate: ratePerSecond,
         period,
       },
+      retryDelay,
     });
 
     const schedule = await client.schedules.get(scheduleId);
+
     expect(schedule.flowControlKey).toBe("flow-key");
     expect(schedule.parallelism).toBe(parallelism);
     expect(schedule.ratePerSecond).toBe(ratePerSecond);
     expect(schedule.rate).toBe(ratePerSecond);
     expect(schedule.period).toBe(SECONDS_IN_A_DAY); // 1d in seconds
+    expect(schedule.retryDelayExpression).toBe(retryDelay);
   });
 });

--- a/src/client/schedules.test.ts
+++ b/src/client/schedules.test.ts
@@ -170,6 +170,8 @@ describe("Schedules", () => {
           scheduleId: "asd",
           destination: MOCK_SERVER_URL,
           cron: "* * * * 1",
+          retries: 3,
+          retryDelay: "pow(retried, 2) * 1000",
           body: JSON.stringify([
             {
               from: "Acme <onboarding@resend.dev>",
@@ -219,6 +221,10 @@ describe("Schedules", () => {
           [`upstash-forward-${requestHeader}`]: requestHeaderValue,
           [`upstash-forward-${globalHeader}`]: globalHeaderValue,
           [`upstash-forward-${globalHeaderOverwritten}`]: overWrittenNewValue,
+          "upstash-cron": "* * * * 1",
+          "upstash-retries": "3",
+          "upstash-schedule-id": "asd",
+          "upstash-retry-after": "pow(retried, 2) * 1000",
         },
       },
     });

--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -37,6 +37,7 @@ export type Schedule = {
    * In seconds.
    */
   period?: number;
+  retryDelayExpression?: PublishRequest["retryDelay"];
 };
 
 export type CreateScheduleRequest = {
@@ -185,7 +186,7 @@ export class Schedules {
     }
 
     if (request.retryDelay !== undefined) {
-      headers.set("Upstash-Retry-After", request.retryDelay);
+      headers.set("Upstash-Retry-Delay", request.retryDelay);
     }
 
     if (request.callback !== undefined) {

--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -37,6 +37,10 @@ export type Schedule = {
    * In seconds.
    */
   period?: number;
+  /**
+   * The retry delay expression for this schedule,
+   * if retry_delay was set when creating the schedule.
+   */
   retryDelayExpression?: PublishRequest["retryDelay"];
 };
 

--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -4,6 +4,7 @@ import type { Requester } from "./http";
 import type { BodyInit, FlowControl, HeadersInit, HTTPMethods } from "./types";
 import type { Duration } from "./duration";
 import { QstashError } from "./error";
+import type { PublishRequest } from "./client";
 
 export type Schedule = {
   scheduleId: string;
@@ -142,7 +143,7 @@ export type CreateScheduleRequest = {
    * and number of requests per second with the same key.
    */
   flowControl?: FlowControl;
-};
+} & Pick<PublishRequest, "retryDelay">;
 
 export class Schedules {
   private readonly http: Requester;
@@ -181,6 +182,10 @@ export class Schedules {
 
     if (request.retries !== undefined) {
       headers.set("Upstash-Retries", request.retries.toFixed(0));
+    }
+
+    if (request.retryDelay !== undefined) {
+      headers.set("Upstash-Retry-After", request.retryDelay);
     }
 
     if (request.callback !== undefined) {

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -85,7 +85,7 @@ export function processHeaders(request: PublishRequest) {
   }
 
   if (request.retryDelay !== undefined) {
-    headers.set("Upstash-Retry-After", request.retryDelay);
+    headers.set("Upstash-Retry-Delay", request.retryDelay);
   }
 
   if (request.callback !== undefined) {

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -84,6 +84,10 @@ export function processHeaders(request: PublishRequest) {
     headers.set("Upstash-Retries", request.retries.toFixed(0));
   }
 
+  if (request.retryDelay !== undefined) {
+    headers.set("Upstash-Retry-After", request.retryDelay);
+  }
+
   if (request.callback !== undefined) {
     headers.set("Upstash-Callback", request.callback);
   }
@@ -131,7 +135,6 @@ export function processHeaders(request: PublishRequest) {
 export function getRequestPath(
   request: Pick<PublishRequest, "url" | "urlGroup" | "api" | "topic">
 ): string {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const nonApiPath = request.url ?? request.urlGroup ?? request.topic;
   if (nonApiPath) return nonApiPath;
 


### PR DESCRIPTION
Adds retryDelay to dynamicaly program the retry duration.

The new parameter is available in publish/batch/enqueue/schedules:

```ts
await client.publishJSON({
  urlGroup: "my-group",
  flowControl: {
    key: flowControlKey,
    parallelism: 3,
    ratePerSecond: 5,
  },
  retryDelay: "pow(retried, 2) * 1000",
});
```