### PR TITLE
feat: add AutoSend email provider integration

### DIFF
--- a/src/client/api/email.test.ts
+++ b/src/client/api/email.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from "bun:test";
 import { Client } from "../client";
-import { resend } from "./email";
+import { resend, autosend } from "./email";
 import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "../workflow/test-utils";
 import { nanoid } from "../utils";
 
@@ -258,6 +258,273 @@ describe("email", () => {
           [`upstash-forward-${globalHeader}`]: globalHeaderValue,
           [`upstash-forward-${globalHeaderOverwritten}`]: overWrittenNewValue,
           "upstash-retry-delay": "pow(retried, 2) * 1000",
+        },
+      },
+    });
+  });
+});
+
+describe("autosend", () => {
+  const qstashToken = nanoid();
+  const autosendToken = nanoid();
+
+  const globalHeader = "global-header";
+  const globalHeaderOverwritten = "global-header-overwritten";
+  const requestHeader = "request-header";
+
+  const globalHeaderValue = nanoid();
+  const overWrittenOldValue = nanoid();
+  const overWrittenNewValue = nanoid();
+  const requestHeaderValue = nanoid();
+
+  const client = new Client({
+    baseUrl: MOCK_QSTASH_SERVER_URL,
+    token: qstashToken,
+    headers: {
+      [globalHeader]: globalHeaderValue,
+      [globalHeaderOverwritten]: overWrittenOldValue,
+    },
+  });
+
+  test("should use autosend to send a single email", async () => {
+    await mockQStashServer({
+      execute: async () => {
+        await client.publishJSON({
+          api: {
+            name: "email",
+            provider: autosend({ token: autosendToken }),
+          },
+          body: {
+            from: { email: "hello@autosend.dev", name: "Acme" },
+            to: { email: "delivered@example.com", name: "User" },
+            subject: "hello world",
+            html: "<p>it works!</p>",
+          },
+          headers: {
+            "content-type": "application/json",
+            [globalHeaderOverwritten]: overWrittenNewValue,
+            [requestHeader]: requestHeaderValue,
+          },
+        });
+      },
+      responseFields: {
+        body: { success: true, data: { emailId: "email-123", message: "Email sent", totalRecipients: 1 } },
+        status: 200,
+      },
+      receivesRequest: {
+        method: "POST",
+        token: qstashToken,
+        url: "http://localhost:8080/v2/publish/https://api.autosend.com/v1/mails/send",
+        body: {
+          from: { email: "hello@autosend.dev", name: "Acme" },
+          to: { email: "delivered@example.com", name: "User" },
+          subject: "hello world",
+          html: "<p>it works!</p>",
+        },
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${qstashToken}`,
+          "upstash-forward-authorization": `Bearer ${autosendToken}`,
+          [`upstash-forward-${requestHeader}`]: requestHeaderValue,
+          [`upstash-forward-${globalHeader}`]: globalHeaderValue,
+          [`upstash-forward-${globalHeaderOverwritten}`]: overWrittenNewValue,
+          "upstash-method": "POST",
+        },
+      },
+    });
+  });
+
+  test("should use autosend with bulk", async () => {
+    await mockQStashServer({
+      execute: async () => {
+        await client.publishJSON({
+          api: {
+            name: "email",
+            provider: autosend({ token: autosendToken, batch: true }),
+          },
+          body: {
+            from: { email: "hello@autosend.dev", name: "Acme" },
+            subject: "hello world",
+            html: "<h1>it works!</h1>",
+            recipients: [
+              { email: "foo@gmail.com", name: "Foo" },
+              { email: "bar@outlook.com", name: "Bar" },
+            ],
+          },
+          headers: {
+            "content-type": "application/json",
+            [globalHeaderOverwritten]: overWrittenNewValue,
+            [requestHeader]: requestHeaderValue,
+          },
+        });
+      },
+      responseFields: {
+        body: { success: true, data: { batchId: "batch-123", totalRecipients: 2, successCount: 2, failedCount: 0 } },
+        status: 200,
+      },
+      receivesRequest: {
+        method: "POST",
+        token: qstashToken,
+        url: "http://localhost:8080/v2/publish/https://api.autosend.com/v1/mails/bulk",
+        body: {
+          from: { email: "hello@autosend.dev", name: "Acme" },
+          subject: "hello world",
+          html: "<h1>it works!</h1>",
+          recipients: [
+            { email: "foo@gmail.com", name: "Foo" },
+            { email: "bar@outlook.com", name: "Bar" },
+          ],
+        },
+        headers: {
+          authorization: `Bearer ${qstashToken}`,
+          "upstash-forward-authorization": `Bearer ${autosendToken}`,
+          "upstash-method": "POST",
+          "content-type": "application/json",
+          [`upstash-forward-${requestHeader}`]: requestHeaderValue,
+          [`upstash-forward-${globalHeader}`]: globalHeaderValue,
+          [`upstash-forward-${globalHeaderOverwritten}`]: overWrittenNewValue,
+        },
+      },
+    });
+  });
+
+  test("should be able to overwrite method", async () => {
+    await mockQStashServer({
+      execute: async () => {
+        await client.publishJSON({
+          api: {
+            name: "email",
+            provider: autosend({ token: autosendToken }),
+          },
+          method: "PUT",
+          body: {
+            from: { email: "hello@autosend.dev", name: "Acme" },
+            to: { email: "delivered@example.com" },
+            subject: "hello world",
+            html: "<p>it works!</p>",
+          },
+        });
+      },
+      responseFields: {
+        body: { success: true, data: { emailId: "email-123" } },
+        status: 200,
+      },
+      receivesRequest: {
+        method: "POST",
+        token: qstashToken,
+        url: "http://localhost:8080/v2/publish/https://api.autosend.com/v1/mails/send",
+        body: {
+          from: { email: "hello@autosend.dev", name: "Acme" },
+          to: { email: "delivered@example.com" },
+          subject: "hello world",
+          html: "<p>it works!</p>",
+        },
+        headers: {
+          authorization: `Bearer ${qstashToken}`,
+          "upstash-forward-authorization": `Bearer ${autosendToken}`,
+          "content-type": "application/json",
+          "upstash-method": "PUT",
+        },
+      },
+    });
+  });
+
+  test("should be able to enqueue", async () => {
+    const queueName = "autosend-queue";
+    const queue = client.queue({ queueName });
+    await mockQStashServer({
+      execute: async () => {
+        await queue.enqueueJSON({
+          api: {
+            name: "email",
+            provider: autosend({ token: autosendToken, batch: true }),
+          },
+          body: {
+            from: { email: "hello@autosend.dev", name: "Acme" },
+            subject: "hello world",
+            html: "<h1>it works!</h1>",
+            recipients: [
+              { email: "foo@gmail.com", name: "Foo" },
+              { email: "bar@outlook.com", name: "Bar" },
+            ],
+          },
+          retryDelay: "pow(retried, 2) * 1000",
+          headers: {
+            "content-type": "application/json",
+            [globalHeaderOverwritten]: overWrittenNewValue,
+            [requestHeader]: requestHeaderValue,
+          },
+        });
+      },
+      responseFields: {
+        body: { success: true, data: { batchId: "batch-456" } },
+        status: 200,
+      },
+      receivesRequest: {
+        method: "POST",
+        token: qstashToken,
+        url: "http://localhost:8080/v2/enqueue/autosend-queue/https://api.autosend.com/v1/mails/bulk",
+        body: {
+          from: { email: "hello@autosend.dev", name: "Acme" },
+          subject: "hello world",
+          html: "<h1>it works!</h1>",
+          recipients: [
+            { email: "foo@gmail.com", name: "Foo" },
+            { email: "bar@outlook.com", name: "Bar" },
+          ],
+        },
+        headers: {
+          authorization: `Bearer ${qstashToken}`,
+          "upstash-forward-authorization": `Bearer ${autosendToken}`,
+          "content-type": "application/json",
+          "upstash-method": "POST",
+          [`upstash-forward-${requestHeader}`]: requestHeaderValue,
+          [`upstash-forward-${globalHeader}`]: globalHeaderValue,
+          [`upstash-forward-${globalHeaderOverwritten}`]: overWrittenNewValue,
+          "upstash-retry-delay": "pow(retried, 2) * 1000",
+        },
+      },
+    });
+  });
+
+  test("should send email with template and dynamic data", async () => {
+    await mockQStashServer({
+      execute: async () => {
+        await client.publishJSON({
+          api: {
+            name: "email",
+            provider: autosend({ token: autosendToken }),
+          },
+          body: {
+            from: { email: "hello@autosend.dev", name: "Acme" },
+            to: { email: "delivered@example.com" },
+            templateId: "template-abc",
+            dynamicData: { firstName: "John", orderNumber: "12345" },
+          },
+          headers: {
+            "content-type": "application/json",
+          },
+        });
+      },
+      responseFields: {
+        body: { success: true, data: { emailId: "email-789" } },
+        status: 200,
+      },
+      receivesRequest: {
+        method: "POST",
+        token: qstashToken,
+        url: "http://localhost:8080/v2/publish/https://api.autosend.com/v1/mails/send",
+        body: {
+          from: { email: "hello@autosend.dev", name: "Acme" },
+          to: { email: "delivered@example.com" },
+          templateId: "template-abc",
+          dynamicData: { firstName: "John", orderNumber: "12345" },
+        },
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${qstashToken}`,
+          "upstash-forward-authorization": `Bearer ${autosendToken}`,
+          "upstash-method": "POST",
         },
       },
     });

--- a/src/client/api/email.ts
+++ b/src/client/api/email.ts
@@ -34,3 +34,19 @@ export const resend = ({
 }): EmailProvider => {
   return new EmailProvider("https://api.resend.com", token, "resend", batch);
 };
+
+class AutoSendEmailProvider extends EmailProvider {
+  getRoute(): string[] {
+    return this.batch ? ["v1", "mails", "bulk"] : ["v1", "mails", "send"];
+  }
+}
+
+export const autosend = ({
+  token,
+  batch = false,
+}: {
+  token: string;
+  batch?: boolean;
+}): EmailProvider => {
+  return new AutoSendEmailProvider("https://api.autosend.com", token, "autosend", batch);
+};

--- a/src/client/api/index.ts
+++ b/src/client/api/index.ts
@@ -1,2 +1,2 @@
-export { resend } from "./email";
+export { resend, autosend } from "./email";
 export { upstash, openai, anthropic, custom } from "./llm";

--- a/src/client/api/types.ts
+++ b/src/client/api/types.ts
@@ -39,7 +39,7 @@ type PublishApi<TName extends ApiKind, TProvider extends BaseProvider<TName>> = 
 /**
  * Email
  */
-export type EmailOwner = "resend";
+export type EmailOwner = "resend" | "autosend";
 export type PublishEmailApi = Required<PublishApi<"email", BaseProvider<"email", EmailOwner>>>;
 
 /**


### PR DESCRIPTION
## Title
Add AutoSend email provider integration

## Summary
- Adds [AutoSend](https://docs.autosend.com/) as a new email provider.  
- Supports both single email send (/v1/mails/send) and bulk email (/v1/mails/bulk) endpoints  
- Client provides their own AutoSend API token — no server-side secrets needed

## Impact
- No breaking changes — existing  provider is untouched
- Extends the EmailOwner type union from "resend" to "resend" | "autosend"
- New export autosend from the package root

## Note to reviewers
- The AutoSendEmailProvider extends EmailProvider and overrides getRoute(). All other behavior (auth headers, method handling, onFinish) is inherited.
- The autosend() factory follows the exact same pattern as other providers - token provided by the client, batch flag toggles single vs bulk endpoint.
- Auth is handled via Bearer token in the Authorization header, which gets forwarded as Upstash-Forward-Authorization — identical to how it works for other providers.