### PR TITLE
DX-2698: support multiple labels per message

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-deprecated */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { nanoid } from "nanoid";
 import { Client } from "./client";
@@ -26,6 +27,21 @@ describe("E2E Publish", () => {
     });
     const verifiedMessage = await client.messages.get(result.messageId);
     expect(verifiedMessage.label).toBe("test-label");
+  });
+
+  test("should publish a message with multiple labels", async () => {
+    const labelOne = `multi-a-${Date.now()}`;
+    const labelTwo = `multi-b-${Date.now()}`;
+    const result = await client.publish({
+      url: "https://example.com/",
+      body: "test-body",
+      label: [labelOne, labelTwo],
+    });
+    const verifiedMessage = await client.messages.get(result.messageId);
+    // legacy `label` carries only the first label
+    expect(verifiedMessage.label).toBe(labelOne);
+    // new `labels` carries all of them
+    expect(verifiedMessage.labels).toEqual([labelOne, labelTwo]);
   });
   const client = new Client({ token: process.env.QSTASH_TOKEN! });
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -230,9 +230,12 @@ export type PublishRequest<TBody = BodyInit> = {
   /**
    * Assign a label to the request to filter logs later.
    *
+   * Pass an array to attach multiple labels to a single message; they are
+   * sent as a comma-separated value in the `Upstash-Label` header.
+   *
    * @default undefined
    */
-  label?: string;
+  label?: string | string[];
 
   /**
    * Configure which fields should be redacted in logs.

--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -227,6 +227,77 @@ describe("DLQ", () => {
   );
 
   test(
+    "should round-trip multiple labels on a DLQ message (label first, labels all)",
+    async () => {
+      const labelOne = `dlq-multi-a-${Date.now()}`;
+      const labelTwo = `dlq-multi-b-${Date.now()}`;
+
+      const { messageId } = await client.publish({
+        url: `https://httpbin.org/status/400`, // Any broken link will work
+        retries: 0,
+        label: [labelOne, labelTwo],
+      });
+
+      await sleep(4000);
+
+      const dlqLogs = await client.dlq.listMessages({
+        filter: { label: [labelOne, labelTwo] },
+      });
+
+      const message = dlqLogs.messages.find((m) => m.messageId === messageId);
+      expect(message).toBeDefined();
+      // legacy `label` carries only the first label
+      expect(message!.label).toBe(labelOne);
+      // new `labels` carries all of them
+      expect(message!.labels).toEqual([labelOne, labelTwo]);
+
+      await client.dlq.delete({ filter: { label: [labelOne, labelTwo] } });
+    },
+    { timeout: 20_000 }
+  );
+
+  test(
+    "should filter DLQ messages by multiple labels (OR semantics)",
+    async () => {
+      const labelA = `dlq-or-a-${Date.now()}`;
+      const labelB = `dlq-or-b-${Date.now()}`;
+      const labelC = `dlq-or-c-${Date.now()}`;
+
+      // msg1: [A, B], msg2: [B, C], msg3: [C]
+      const { messageId: messageAB } = await client.publish({
+        url: `https://httpbin.org/status/400`,
+        retries: 0,
+        label: [labelA, labelB],
+      });
+      const { messageId: messageBC } = await client.publish({
+        url: `https://httpbin.org/status/400`,
+        retries: 0,
+        label: [labelB, labelC],
+      });
+      const { messageId: messageC } = await client.publish({
+        url: `https://httpbin.org/status/400`,
+        retries: 0,
+        label: labelC,
+      });
+
+      await sleep(4000);
+
+      // filtering by [A, B] should match msgAB and msgBC (both share a label)
+      // but NOT msgC.
+      const dlqLogs = await client.dlq.listMessages({
+        filter: { label: [labelA, labelB] },
+      });
+      const ids = new Set(dlqLogs.messages.map((m) => m.messageId));
+      expect(ids.has(messageAB)).toBe(true);
+      expect(ids.has(messageBC)).toBe(true);
+      expect(ids.has(messageC)).toBe(false);
+
+      await client.dlq.delete({ filter: { label: [labelA, labelB, labelC] } });
+    },
+    { timeout: 20_000 }
+  );
+
+  test(
     "should retry multiple messages from DLQ",
     async () => {
       // Publish multiple messages that will fail
@@ -913,5 +984,45 @@ describe("DLQ - mocked early return", () => {
       query: { dlqIds: [] as string[] },
     });
     expect(promise).rejects.toThrow("Empty array");
+  });
+});
+
+describe("DLQ - mocked filter url shape", () => {
+  const token = "mock-token";
+
+  test("should send a single label as a single query param", async () => {
+    const mockClient = new Client({ token, baseUrl: MOCK_QSTASH_SERVER_URL });
+    await mockQStashServer({
+      execute: async () => {
+        await mockClient.dlq.listMessages({ filter: { label: "label-1" } });
+      },
+      responseFields: { body: { messages: [] }, status: 200 },
+      receivesRequest: {
+        method: "GET",
+        token,
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/dlq?label=label-1`,
+      },
+      validateRequest: (request) => {
+        expect(new URL(request.url).searchParams.getAll("label")).toEqual(["label-1"]);
+      },
+    });
+  });
+
+  test("should send multiple labels as repeated query params (OR semantics)", async () => {
+    const mockClient = new Client({ token, baseUrl: MOCK_QSTASH_SERVER_URL });
+    await mockQStashServer({
+      execute: async () => {
+        await mockClient.dlq.listMessages({ filter: { label: ["label-1", "label-2"] } });
+      },
+      responseFields: { body: { messages: [] }, status: 200 },
+      receivesRequest: {
+        method: "GET",
+        token,
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/dlq?label=label-1&label=label-2`,
+      },
+      validateRequest: (request) => {
+        expect(new URL(request.url).searchParams.getAll("label")).toEqual(["label-1", "label-2"]);
+      },
+    });
   });
 });

--- a/src/client/filter-types.ts
+++ b/src/client/filter-types.ts
@@ -16,7 +16,14 @@ type UniversalFilterFields = {
   fromDate?: Date | number;
   toDate?: Date | number;
   callerIp?: string;
-  label?: string;
+  /**
+   * Filter by label.
+   *
+   * Pass an array to match runs that have any of the given labels (OR semantics).
+   * For example, with runs labelled `[label_1, label_2]` and `[label_2, label_3]`,
+   * filtering by `[label_1, label_2]` returns both.
+   */
+  label?: string | string[];
   flowControlKey?: string;
 };
 

--- a/src/client/logs.test.ts
+++ b/src/client/logs.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { describe, expect, test } from "bun:test";
 import { Client } from "./client";
+import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
 
 describe("logs", () => {
   test(
@@ -31,6 +32,74 @@ describe("logs", () => {
     }
   );
   const client = new Client({ token: process.env.QSTASH_TOKEN! });
+
+  test(
+    "should round-trip multiple labels (label first, labels all)",
+    async () => {
+      const labelOne = `multi-a-${Date.now()}`;
+      const labelTwo = `multi-b-${Date.now()}`;
+
+      const { messageId } = await client.publish({
+        url: "https://example.com",
+        body: "log-multi-label-test",
+        label: [labelOne, labelTwo],
+      });
+
+      await eventually(
+        async () => {
+          const result = await client.logs({ filter: { label: [labelOne, labelTwo] } });
+          const log = result.logs.find((l) => l.messageId === messageId);
+          expect(log).toBeDefined();
+          // legacy `label` carries only the first label
+          expect(log!.label).toBe(labelOne);
+          // new `labels` carries all of them
+          expect(log!.labels).toEqual([labelOne, labelTwo]);
+        },
+        { interval: 1000 }
+      );
+    },
+    { timeout: 10_000 }
+  );
+
+  test(
+    "should filter logs by multiple labels (OR semantics)",
+    async () => {
+      const labelA = `or-a-${Date.now()}`;
+      const labelB = `or-b-${Date.now()}`;
+      const labelC = `or-c-${Date.now()}`;
+
+      // msg1: [A, B], msg2: [B, C], msg3: [C]
+      const { messageId: messageAB } = await client.publish({
+        url: "https://example.com",
+        body: "or-1",
+        label: [labelA, labelB],
+      });
+      const { messageId: messageBC } = await client.publish({
+        url: "https://example.com",
+        body: "or-2",
+        label: [labelB, labelC],
+      });
+      const { messageId: messageC } = await client.publish({
+        url: "https://example.com",
+        body: "or-3",
+        label: labelC,
+      });
+
+      // filtering by [A, B] should match msgAB and msgBC (both share a label)
+      // but NOT msgC.
+      await eventually(
+        async () => {
+          const result = await client.logs({ filter: { label: [labelA, labelB] } });
+          const ids = new Set(result.logs.map((l) => l.messageId));
+          expect(ids.has(messageAB)).toBe(true);
+          expect(ids.has(messageBC)).toBe(true);
+          expect(ids.has(messageC)).toBe(false);
+        },
+        { interval: 1000 }
+      );
+    },
+    { timeout: 15_000 }
+  );
 
   test("should use cursor", async () => {
     await client.logs({
@@ -64,6 +133,46 @@ describe("logs", () => {
     },
     { timeout: 10_000 }
   );
+});
+
+describe("logs - mocked filter url shape", () => {
+  const token = "mock-token";
+
+  test("should send a single label as a single query param", async () => {
+    const client = new Client({ token, baseUrl: MOCK_QSTASH_SERVER_URL });
+    await mockQStashServer({
+      execute: async () => {
+        await client.logs({ filter: { label: "label-1" } });
+      },
+      responseFields: { body: { events: [] }, status: 200 },
+      receivesRequest: {
+        method: "GET",
+        token,
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/events?label=label-1`,
+      },
+      validateRequest: (request) => {
+        expect(new URL(request.url).searchParams.getAll("label")).toEqual(["label-1"]);
+      },
+    });
+  });
+
+  test("should send multiple labels as repeated query params (OR semantics)", async () => {
+    const client = new Client({ token, baseUrl: MOCK_QSTASH_SERVER_URL });
+    await mockQStashServer({
+      execute: async () => {
+        await client.logs({ filter: { label: ["label-1", "label-2"] } });
+      },
+      responseFields: { body: { events: [] }, status: 200 },
+      receivesRequest: {
+        method: "GET",
+        token,
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/events?label=label-1&label=label-2`,
+      },
+      validateRequest: (request) => {
+        expect(new URL(request.url).searchParams.getAll("label")).toEqual(["label-1", "label-2"]);
+      },
+    });
+  });
 });
 
 describe("events (deprecated)", () => {

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -132,8 +132,18 @@ export type Message = {
 
   /**
    * The label assigned to the message for filtering purposes.
+   *
+   * @deprecated Use `labels` instead. When a message has multiple labels, this
+   *   field only contains the first one.
    */
   label?: string;
+
+  /**
+   * The labels assigned to the message for filtering purposes.
+   *
+   * A message can have multiple labels when published with `label: string[]`.
+   */
+  labels?: string[];
 };
 
 export type MessagePayload = Omit<Message, "urlGroup"> & { topicName: string };

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -24,7 +24,19 @@ export type Log = {
   endpointName?: string;
   header?: Record<string, string>;
   body?: string; // base64 encoded
+  /**
+   * Label of the message.
+   *
+   * @deprecated Use `labels` instead. When a message has multiple labels, this
+   *   field only contains the first one.
+   */
   label?: string;
+  /**
+   * Labels attached to the message.
+   *
+   * A message can have multiple labels when published with `label: string[]`.
+   */
+  labels?: string[];
 };
 
 /**

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -1,11 +1,11 @@
 import {
   buildBulkActionFilterPayload,
   DEFAULT_BULK_COUNT,
+  prefixHeaders,
   processHeaders,
   serializeLabel,
 } from "./utils";
 import { describe, expect, test } from "bun:test";
-import { prefixHeaders } from "./utils";
 import type { DLQBulkActionFilters } from "./filter-types";
 
 describe("prefixHeaders", () => {

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -1,4 +1,9 @@
-import { buildBulkActionFilterPayload, DEFAULT_BULK_COUNT, processHeaders } from "./utils";
+import {
+  buildBulkActionFilterPayload,
+  DEFAULT_BULK_COUNT,
+  processHeaders,
+  serializeLabel,
+} from "./utils";
 import { describe, expect, test } from "bun:test";
 import { prefixHeaders } from "./utils";
 import type { DLQBulkActionFilters } from "./filter-types";
@@ -77,9 +82,27 @@ describe("buildFilterPayload", () => {
   });
 });
 
+describe("serializeLabel", () => {
+  test("should return a single label as-is", () => {
+    expect(serializeLabel("my-label")).toBe("my-label");
+  });
+
+  test("should join multiple labels with a comma", () => {
+    expect(serializeLabel(["label-1", "label-2"])).toBe("label-1,label-2");
+  });
+});
+
 describe("processHeaders", () => {
   test("should set Upstash-Label header if label is present", () => {
     const headers = processHeaders({ url: "https://example.com", label: "my-label" });
     expect(headers.get("Upstash-Label")).toBe("my-label");
+  });
+
+  test("should set comma-separated Upstash-Label header for an array of labels", () => {
+    const headers = processHeaders({
+      url: "https://example.com",
+      label: ["label-1", "label-2"],
+    });
+    expect(headers.get("Upstash-Label")).toBe("label-1,label-2");
   });
 });

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -6,6 +6,15 @@ import type { DLQBulkActionFilters, MessageCancelFilters } from "./filter-types"
 
 export const DEFAULT_BULK_COUNT = 100;
 
+/**
+ * Serializes a label (string or array of strings) into the header value.
+ * Arrays are joined with `,` so multiple labels can be sent in a single
+ * `Upstash-Label` header.
+ */
+export function serializeLabel(label: string | string[]): string {
+  return Array.isArray(label) ? label.join(",") : label;
+}
+
 const isIgnoredHeader = (header: string) => {
   const lowerCaseHeader = header.toLowerCase();
   return lowerCaseHeader.startsWith("content-type") || lowerCaseHeader.startsWith("upstash-");
@@ -133,7 +142,7 @@ export function processHeaders(request: PublishRequest) {
   }
 
   if (request.label !== undefined) {
-    headers.set("Upstash-Label", request.label);
+    headers.set("Upstash-Label", serializeLabel(request.label));
   }
 
   if (request.redact !== undefined) {

--- a/src/dev-server/health.ts
+++ b/src/dev-server/health.ts
@@ -47,7 +47,9 @@ export const checkDevServerReachable = async (
 const pingEdge = async (baseUrl: string): Promise<boolean> => {
   try {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT_MS);
+    const timeout = setTimeout(() => {
+      controller.abort();
+    }, HEALTH_CHECK_TIMEOUT_MS);
     const response = await fetch(`${baseUrl}/v2/keys`, {
       headers: { Authorization: `Bearer ${DEV_CREDENTIALS.token}` },
       signal: controller.signal,


### PR DESCRIPTION

- Source: client.ts (publish label: string | string[]), utils.ts (serializeLabel + comma-joined header),
filter-types.ts (filter label: string | string[], OR docs), types.ts + messages.ts (deprecate label, add
labels: string[]).
- Tests: mocked serialization/URL-shape (utils.test.ts, logs.test.ts, dlq.test.ts) and live round-trip +
OR tests (logs.test.ts, dlq.test.ts, client.test.ts).