### PR TITLE
DX-2769: reject empty id in single-resource endpoints

### DIFF
--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -6,7 +6,7 @@ import { sleep } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Client } from "./client";
 import { eventually } from "./logs.test";
-import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
+import { MOCK_QSTASH_SERVER_URL, mockQStashServer, expectToReject } from "./workflow/test-utils";
 import type { HttpClient } from "./http";
 
 // Updated to use constants for magic numbers
@@ -971,12 +971,12 @@ describe("DLQ - mocked early return", () => {
 
   test("should not send request when delete is called with an empty string", async () => {
     await mockQStashServer({
-      execute: () => {
+      execute: async () => {
         const mockClient = new Client({
           token: "mock-token",
           baseUrl: MOCK_QSTASH_SERVER_URL,
         });
-        expect(mockClient.dlq.delete("")).rejects.toThrow("DLQ id cannot be empty");
+        await expectToReject(() => mockClient.dlq.delete(""), "DLQ id cannot be empty");
       },
       responseFields: { body: {}, status: 200 },
       receivesRequest: false,

--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -969,6 +969,20 @@ describe("DLQ - mocked early return", () => {
     });
   });
 
+  test("should not send request when delete is called with an empty string", async () => {
+    await mockQStashServer({
+      execute: () => {
+        const mockClient = new Client({
+          token: "mock-token",
+          baseUrl: MOCK_QSTASH_SERVER_URL,
+        });
+        expect(mockClient.dlq.delete("")).rejects.toThrow("DLQ id cannot be empty");
+      },
+      responseFields: { body: {}, status: 200 },
+      receivesRequest: false,
+    });
+  });
+
   // eslint-disable-next-line @typescript-eslint/require-await
   test("http client should throw when empty array is passed in query params", async () => {
     const mockClient = new Client({

--- a/src/client/dlq.ts
+++ b/src/client/dlq.ts
@@ -1,7 +1,12 @@
 import type { Requester } from "./http";
 import type { Message } from "./messages";
 import type { DLQBulkActionFilters, DLQListRequest } from "./filter-types";
-import { buildBulkActionFilterPayload, normalizeCursor, renameUrlGroup } from "./utils";
+import {
+  assertNonEmptyId,
+  buildBulkActionFilterPayload,
+  normalizeCursor,
+  renameUrlGroup,
+} from "./utils";
 
 type DlqMessage = Message & {
   /**
@@ -113,6 +118,7 @@ export class DLQ {
     // Handle single string via single-item endpoint to preserve 404 semantics.
     // For backwards compatibility
     if (typeof request === "string") {
+      assertNonEmptyId(request, "DLQ id");
       await this.http.request({
         method: "DELETE",
         path: ["v2", "dlq", request],

--- a/src/client/flow-control.test.ts
+++ b/src/client/flow-control.test.ts
@@ -3,17 +3,20 @@
 
 import { describe, expect, test } from "bun:test";
 import { Client } from "./client";
-import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
+import { MOCK_QSTASH_SERVER_URL, mockQStashServer, expectToReject } from "./workflow/test-utils";
 
 describe("FlowControl empty id guard", () => {
   test("should not send request when get is called with an empty string", async () => {
     await mockQStashServer({
-      execute: () => {
+      execute: async () => {
         const mockClient = new Client({
           token: "mock-token",
           baseUrl: MOCK_QSTASH_SERVER_URL,
         });
-        expect(mockClient.flowControl.get("")).rejects.toThrow("Flow control key cannot be empty");
+        await expectToReject(
+          () => mockClient.flowControl.get(""),
+          "Flow control key cannot be empty"
+        );
       },
       responseFields: { body: {}, status: 200 },
       receivesRequest: false,

--- a/src/client/flow-control.test.ts
+++ b/src/client/flow-control.test.ts
@@ -3,6 +3,23 @@
 
 import { describe, expect, test } from "bun:test";
 import { Client } from "./client";
+import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
+
+describe("FlowControl empty id guard", () => {
+  test("should not send request when get is called with an empty string", async () => {
+    await mockQStashServer({
+      execute: () => {
+        const mockClient = new Client({
+          token: "mock-token",
+          baseUrl: MOCK_QSTASH_SERVER_URL,
+        });
+        expect(mockClient.flowControl.get("")).rejects.toThrow("Flow control key cannot be empty");
+      },
+      responseFields: { body: {}, status: 200 },
+      receivesRequest: false,
+    });
+  });
+});
 
 describe("FlowControl", () => {
   const client = new Client({ token: process.env.QSTASH_TOKEN! });

--- a/src/client/flow-control.ts
+++ b/src/client/flow-control.ts
@@ -1,4 +1,5 @@
 import type { Requester } from "./http";
+import { assertNonEmptyId } from "./utils";
 
 export type FlowControlInfo = {
   /**
@@ -109,6 +110,7 @@ export class FlowControlApi {
    * Get a single flow control by key.
    */
   public async get(flowControlKey: string): Promise<FlowControlInfo> {
+    assertNonEmptyId(flowControlKey, "Flow control key");
     return await this.http.request<FlowControlInfo>({
       method: "GET",
       path: ["v2", "flowControl", flowControlKey],

--- a/src/client/messages.test.ts
+++ b/src/client/messages.test.ts
@@ -22,6 +22,25 @@ describe("Messages empty id guard", () => {
     });
   });
 
+  test("should throw a QstashError (not a TypeError) when get is called with undefined", async () => {
+    await mockQStashServer({
+      execute: async () => {
+        const mockClient = new Client({
+          token: "mock-token",
+          baseUrl: MOCK_QSTASH_SERVER_URL,
+        });
+        // A JS consumer may accidentally pass a missing value; it should fail
+        // with the intended "cannot be empty" error, not a TypeError.
+        await expectToReject(
+          () => mockClient.messages.get(undefined as unknown as string),
+          "Message id cannot be empty"
+        );
+      },
+      responseFields: { body: {}, status: 200 },
+      receivesRequest: false,
+    });
+  });
+
   test("should not send request when cancel is called with an empty string", async () => {
     await mockQStashServer({
       execute: async () => {

--- a/src/client/messages.test.ts
+++ b/src/client/messages.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 import { beforeAll, describe, expect, test } from "bun:test";
 import { Client } from "./client";
-import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
+import { MOCK_QSTASH_SERVER_URL, mockQStashServer, expectToReject } from "./workflow/test-utils";
 
 // Updated to use constants for magic numbers
 const SECONDS_IN_A_DAY = 24 * 60 * 60;
@@ -10,12 +10,12 @@ const SECONDS_IN_A_DAY = 24 * 60 * 60;
 describe("Messages empty id guard", () => {
   test("should not send request when get is called with an empty string", async () => {
     await mockQStashServer({
-      execute: () => {
+      execute: async () => {
         const mockClient = new Client({
           token: "mock-token",
           baseUrl: MOCK_QSTASH_SERVER_URL,
         });
-        expect(mockClient.messages.get("")).rejects.toThrow("Message id cannot be empty");
+        await expectToReject(() => mockClient.messages.get(""), "Message id cannot be empty");
       },
       responseFields: { body: {}, status: 200 },
       receivesRequest: false,
@@ -24,12 +24,12 @@ describe("Messages empty id guard", () => {
 
   test("should not send request when cancel is called with an empty string", async () => {
     await mockQStashServer({
-      execute: () => {
+      execute: async () => {
         const mockClient = new Client({
           token: "mock-token",
           baseUrl: MOCK_QSTASH_SERVER_URL,
         });
-        expect(mockClient.messages.cancel("")).rejects.toThrow("Message id cannot be empty");
+        await expectToReject(() => mockClient.messages.cancel(""), "Message id cannot be empty");
       },
       responseFields: { body: {}, status: 200 },
       receivesRequest: false,
@@ -38,13 +38,16 @@ describe("Messages empty id guard", () => {
 
   test("should not send request when delete is called with an empty string", async () => {
     await mockQStashServer({
-      execute: () => {
+      execute: async () => {
         const mockClient = new Client({
           token: "mock-token",
           baseUrl: MOCK_QSTASH_SERVER_URL,
         });
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        expect(mockClient.messages.delete("")).rejects.toThrow("Message id cannot be empty");
+        await expectToReject(
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
+          () => mockClient.messages.delete(""),
+          "Message id cannot be empty"
+        );
       },
       responseFields: { body: {}, status: 200 },
       receivesRequest: false,

--- a/src/client/messages.test.ts
+++ b/src/client/messages.test.ts
@@ -2,9 +2,55 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 import { beforeAll, describe, expect, test } from "bun:test";
 import { Client } from "./client";
+import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
 
 // Updated to use constants for magic numbers
 const SECONDS_IN_A_DAY = 24 * 60 * 60;
+
+describe("Messages empty id guard", () => {
+  test("should not send request when get is called with an empty string", async () => {
+    await mockQStashServer({
+      execute: () => {
+        const mockClient = new Client({
+          token: "mock-token",
+          baseUrl: MOCK_QSTASH_SERVER_URL,
+        });
+        expect(mockClient.messages.get("")).rejects.toThrow("Message id cannot be empty");
+      },
+      responseFields: { body: {}, status: 200 },
+      receivesRequest: false,
+    });
+  });
+
+  test("should not send request when cancel is called with an empty string", async () => {
+    await mockQStashServer({
+      execute: () => {
+        const mockClient = new Client({
+          token: "mock-token",
+          baseUrl: MOCK_QSTASH_SERVER_URL,
+        });
+        expect(mockClient.messages.cancel("")).rejects.toThrow("Message id cannot be empty");
+      },
+      responseFields: { body: {}, status: 200 },
+      receivesRequest: false,
+    });
+  });
+
+  test("should not send request when delete is called with an empty string", async () => {
+    await mockQStashServer({
+      execute: () => {
+        const mockClient = new Client({
+          token: "mock-token",
+          baseUrl: MOCK_QSTASH_SERVER_URL,
+        });
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        expect(mockClient.messages.delete("")).rejects.toThrow("Message id cannot be empty");
+      },
+      responseFields: { body: {}, status: 200 },
+      receivesRequest: false,
+    });
+  });
+});
 
 describe("Messages", () => {
   const client = new Client({ token: process.env.QSTASH_TOKEN! });

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -2,7 +2,7 @@ import type { PublishRequest } from "./client";
 import type { Requester } from "./http";
 import type { HTTPMethods } from "./types";
 import type { MessageCancelFilters } from "./filter-types";
-import { buildBulkActionFilterPayload } from "./utils";
+import { assertNonEmptyId, buildBulkActionFilterPayload } from "./utils";
 
 export type Message = {
   /**
@@ -159,6 +159,7 @@ export class Messages {
    * Get a message
    */
   public async get(messageId: string): Promise<Message> {
+    assertNonEmptyId(messageId, "Message id");
     const messagePayload = await this.http.request<MessagePayload>({
       method: "GET",
       path: ["v2", "messages", messageId],
@@ -196,6 +197,7 @@ export class Messages {
   ): Promise<{ cancelled: number }> {
     // Handle single string separately, for backwards compatibility on the response
     if (typeof request === "string") {
+      assertNonEmptyId(request, "Message id");
       return await this.http.request({
         method: "DELETE",
         path: ["v2", "messages", request],
@@ -221,6 +223,7 @@ export class Messages {
    * @deprecated Use `cancel(messageId: string)` instead
    */
   public async delete(messageId: string): Promise<void> {
+    assertNonEmptyId(messageId, "Message id");
     await this.http.request({
       method: "DELETE",
       path: ["v2", "messages", messageId],

--- a/src/client/schedules.test.ts
+++ b/src/client/schedules.test.ts
@@ -306,3 +306,33 @@ describe("Schedules", () => {
     });
   });
 });
+
+describe("Schedules empty id guard", () => {
+  test("should not send request when get is called with an empty string", async () => {
+    await mockQStashServer({
+      execute: () => {
+        const mockClient = new Client({
+          token: "mock-token",
+          baseUrl: MOCK_QSTASH_SERVER_URL,
+        });
+        expect(mockClient.schedules.get("")).rejects.toThrow("Schedule id cannot be empty");
+      },
+      responseFields: { body: {}, status: 200 },
+      receivesRequest: false,
+    });
+  });
+
+  test("should not send request when delete is called with an empty string", async () => {
+    await mockQStashServer({
+      execute: () => {
+        const mockClient = new Client({
+          token: "mock-token",
+          baseUrl: MOCK_QSTASH_SERVER_URL,
+        });
+        expect(mockClient.schedules.delete("")).rejects.toThrow("Schedule id cannot be empty");
+      },
+      responseFields: { body: {}, status: 200 },
+      receivesRequest: false,
+    });
+  });
+});

--- a/src/client/schedules.test.ts
+++ b/src/client/schedules.test.ts
@@ -5,7 +5,12 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { Client } from "./client";
 import type { Schedule } from "./schedules";
 import { nanoid } from "nanoid";
-import { MOCK_QSTASH_SERVER_URL, MOCK_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
+import {
+  MOCK_QSTASH_SERVER_URL,
+  MOCK_SERVER_URL,
+  mockQStashServer,
+  expectToReject,
+} from "./workflow/test-utils";
 
 // Updated to use constants for magic numbers
 const SECONDS_IN_A_DAY = 24 * 60 * 60;
@@ -310,12 +315,12 @@ describe("Schedules", () => {
 describe("Schedules empty id guard", () => {
   test("should not send request when get is called with an empty string", async () => {
     await mockQStashServer({
-      execute: () => {
+      execute: async () => {
         const mockClient = new Client({
           token: "mock-token",
           baseUrl: MOCK_QSTASH_SERVER_URL,
         });
-        expect(mockClient.schedules.get("")).rejects.toThrow("Schedule id cannot be empty");
+        await expectToReject(() => mockClient.schedules.get(""), "Schedule id cannot be empty");
       },
       responseFields: { body: {}, status: 200 },
       receivesRequest: false,
@@ -324,12 +329,12 @@ describe("Schedules empty id guard", () => {
 
   test("should not send request when delete is called with an empty string", async () => {
     await mockQStashServer({
-      execute: () => {
+      execute: async () => {
         const mockClient = new Client({
           token: "mock-token",
           baseUrl: MOCK_QSTASH_SERVER_URL,
         });
-        expect(mockClient.schedules.delete("")).rejects.toThrow("Schedule id cannot be empty");
+        await expectToReject(() => mockClient.schedules.delete(""), "Schedule id cannot be empty");
       },
       responseFields: { body: {}, status: 200 },
       receivesRequest: false,

--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-deprecated */
-import { prefixHeaders, wrapWithGlobalHeaders } from "./utils";
+import { assertNonEmptyId, prefixHeaders, wrapWithGlobalHeaders } from "./utils";
 import type { Requester } from "./http";
 import type { BodyInit, FlowControl, HeadersInit, HTTPMethods } from "./types";
 import type { Duration } from "./duration";
@@ -329,6 +329,7 @@ export class Schedules {
    * Get a schedule
    */
   public async get(scheduleId: string): Promise<Schedule> {
+    assertNonEmptyId(scheduleId, "Schedule id");
     const schedule = await this.http.request<Schedule>({
       method: "GET",
       path: ["v2", "schedules", scheduleId],
@@ -359,6 +360,7 @@ export class Schedules {
    * Delete a schedule
    */
   public async delete(scheduleId: string): Promise<void> {
+    assertNonEmptyId(scheduleId, "Schedule id");
     return await this.http.request({
       method: "DELETE",
       path: ["v2", "schedules", scheduleId],

--- a/src/client/url-groups.test.ts
+++ b/src/client/url-groups.test.ts
@@ -1,17 +1,17 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { describe, expect, test } from "bun:test";
 import { Client } from "./client";
-import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
+import { MOCK_QSTASH_SERVER_URL, mockQStashServer, expectToReject } from "./workflow/test-utils";
 
 describe("url group empty id guard", () => {
   test("should not send request when get is called with an empty string", async () => {
     await mockQStashServer({
-      execute: () => {
+      execute: async () => {
         const mockClient = new Client({
           token: "mock-token",
           baseUrl: MOCK_QSTASH_SERVER_URL,
         });
-        expect(mockClient.urlGroups.get("")).rejects.toThrow("Url group name cannot be empty");
+        await expectToReject(() => mockClient.urlGroups.get(""), "Url group name cannot be empty");
       },
       responseFields: { body: {}, status: 200 },
       receivesRequest: false,
@@ -20,12 +20,15 @@ describe("url group empty id guard", () => {
 
   test("should not send request when delete is called with an empty string", async () => {
     await mockQStashServer({
-      execute: () => {
+      execute: async () => {
         const mockClient = new Client({
           token: "mock-token",
           baseUrl: MOCK_QSTASH_SERVER_URL,
         });
-        expect(mockClient.urlGroups.delete("")).rejects.toThrow("Url group name cannot be empty");
+        await expectToReject(
+          () => mockClient.urlGroups.delete(""),
+          "Url group name cannot be empty"
+        );
       },
       responseFields: { body: {}, status: 200 },
       receivesRequest: false,

--- a/src/client/url-groups.test.ts
+++ b/src/client/url-groups.test.ts
@@ -1,6 +1,37 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { describe, expect, test } from "bun:test";
 import { Client } from "./client";
+import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
+
+describe("url group empty id guard", () => {
+  test("should not send request when get is called with an empty string", async () => {
+    await mockQStashServer({
+      execute: () => {
+        const mockClient = new Client({
+          token: "mock-token",
+          baseUrl: MOCK_QSTASH_SERVER_URL,
+        });
+        expect(mockClient.urlGroups.get("")).rejects.toThrow("Url group name cannot be empty");
+      },
+      responseFields: { body: {}, status: 200 },
+      receivesRequest: false,
+    });
+  });
+
+  test("should not send request when delete is called with an empty string", async () => {
+    await mockQStashServer({
+      execute: () => {
+        const mockClient = new Client({
+          token: "mock-token",
+          baseUrl: MOCK_QSTASH_SERVER_URL,
+        });
+        expect(mockClient.urlGroups.delete("")).rejects.toThrow("Url group name cannot be empty");
+      },
+      responseFields: { body: {}, status: 200 },
+      receivesRequest: false,
+    });
+  });
+});
 
 describe("url group", () => {
   const client = new Client({ token: process.env.QSTASH_TOKEN! });

--- a/src/client/url-groups.ts
+++ b/src/client/url-groups.ts
@@ -1,4 +1,5 @@
 import type { Requester } from "./http";
+import { assertNonEmptyId } from "./utils";
 
 export type Endpoint = {
   /**
@@ -108,6 +109,7 @@ export class UrlGroups {
    * Get a single url group
    */
   public async get(name: string): Promise<UrlGroup> {
+    assertNonEmptyId(name, "Url group name");
     return await this.http.request<UrlGroup>({
       method: "GET",
       path: ["v2", "topics", name],
@@ -118,6 +120,7 @@ export class UrlGroups {
    * Delete a url group
    */
   public async delete(name: string): Promise<void> {
+    assertNonEmptyId(name, "Url group name");
     return await this.http.request({
       method: "DELETE",
       path: ["v2", "topics", name],

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -7,6 +7,20 @@ import type { DLQBulkActionFilters, MessageCancelFilters } from "./filter-types"
 export const DEFAULT_BULK_COUNT = 100;
 
 /**
+ * Guards single-resource endpoints against an empty identifier.
+ *
+ * An empty id would otherwise be joined into the path as a trailing slash
+ * (e.g. `v2/messages/`), which the server resolves to the collection/bulk
+ * endpoint. For DELETE methods this silently triggers a bulk delete, so we
+ * fail fast instead.
+ */
+export function assertNonEmptyId(id: string, label = "id"): void {
+  if (id.length === 0) {
+    throw new QstashError(`${label} cannot be empty`);
+  }
+}
+
+/**
  * Serializes a label (string or array of strings) into the header value.
  * Arrays are joined with `,` so multiple labels can be sent in a single
  * `Upstash-Label` header.

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -7,15 +7,19 @@ import type { DLQBulkActionFilters, MessageCancelFilters } from "./filter-types"
 export const DEFAULT_BULK_COUNT = 100;
 
 /**
- * Guards single-resource endpoints against an empty identifier.
+ * Guards single-resource endpoints against a missing identifier.
  *
  * An empty id would otherwise be joined into the path as a trailing slash
  * (e.g. `v2/messages/`), which the server resolves to the collection/bulk
  * endpoint. For DELETE methods this silently triggers a bulk delete, so we
  * fail fast instead.
+ *
+ * Uses a falsy check rather than `id.length` so that a JS consumer passing
+ * `undefined`/`null` fails with a consistent `QstashError` instead of a
+ * `TypeError`.
  */
 export function assertNonEmptyId(id: string, label = "id"): void {
-  if (id.length === 0) {
+  if (!id) {
     throw new QstashError(`${label} cannot be empty`);
   }
 }

--- a/src/client/workflow/test-utils.ts
+++ b/src/client/workflow/test-utils.ts
@@ -13,6 +13,27 @@ export const MOCK_QSTASH_SERVER_URL = `http://localhost:${MOCK_QSTASH_SERVER_POR
 export const MOCK_SERVER_URL = "https://requestcatcher.com/";
 export const WORKFLOW_ENDPOINT = "https://www.my-website.com/api";
 
+/**
+ * Asserts that calling `fn` rejects with an error whose message contains
+ * `message`.
+ *
+ * Unlike a floating `expect(promise).rejects.toThrow(...)`, this awaits the
+ * actual call, so the assertion runs deterministically before the caller (e.g.
+ * `mockQStashServer`) tears down its server — and a regression that resolves or
+ * throws a different error reliably fails the test instead of leaking an
+ * unhandled rejection.
+ */
+export const expectToReject = async (call: () => Promise<unknown>, message: string) => {
+  let error: unknown;
+  try {
+    await call();
+  } catch (error_) {
+    error = error_;
+  }
+  expect(error).toBeInstanceOf(Error);
+  expect((error as Error).message).toContain(message);
+};
+
 export type ResponseFields = {
   body: unknown;
   status: number;


### PR DESCRIPTION
## Summary
Passing an empty string to a single-resource method (e.g. `messages.cancel("")`,
`messages.delete("")`) caused the id to be joined into the path as a trailing
slash (`v2/messages/`), which the server resolves to the **bulk** endpoint —
silently triggering a bulk cancel/delete instead of a no-op or error.

This adds an `assertNonEmptyId` guard so an empty id throws a `QstashError`
before any request is made.

## Changes
- Add `assertNonEmptyId(id, label)` helper in `src/client/utils.ts`
- Guard single-id methods:
  - `messages`: `get`, `cancel` (string form), `delete`
  - `dlq`: `delete` (string form)
  - `schedules`: `get`, `delete`
  - `urlGroups`: `get`, `delete`
  - `flowControl`: `get`
  
## Testing
- 8 new guard tests using `mockQStashServer` with `receivesRequest: false`,
  asserting the call rejects and **no HTTP request is sent**.
- `tsc` and `eslint` clean.