### PR TITLE
feat: add startDevServer public API, S3 binary discovery, and Windows support

### DIFF
--- a/platforms/nextjs.ts
+++ b/platforms/nextjs.ts
@@ -9,7 +9,7 @@ import { Receiver } from "../src/receiver";
 
 import type { WorkflowServeOptions, RouteFunction } from "../src/client/workflow";
 import { serve as serveBase } from "../src/client/workflow";
-import { ensureDevelopmentServer, shouldUseDevelopmentMode } from "../src/dev-server";
+import { shouldUseDevelopmentMode, startDevServer } from "../src/dev-server";
 
 export type VerifySignatureConfig = {
   currentSigningKey?: string;
@@ -283,6 +283,10 @@ export const servePagesRouter = <TInitialPayload = unknown>(
 /**
  * Start the QStash dev server early during Next.js initialization.
  *
+ * @deprecated Use {@link startDevServer} from `@upstash/qstash` instead. It is
+ * the same env-gated, idempotent, never-throwing entry point and works from any
+ * runtime/script, not just Next.js. This alias is kept for back-compat.
+ *
  * Call this inside your `instrumentation.ts` `register()` function so
  * the dev server is ready before any request — including edge routes
  * that cannot start it themselves.
@@ -292,21 +296,13 @@ export const servePagesRouter = <TInitialPayload = unknown>(
  * @example
  * ```ts
  * // instrumentation.ts
- * import { registerQStashDev } from "@upstash/qstash/nextjs";
+ * import { startDevServer } from "@upstash/qstash";
  *
  * export function register() {
- *   registerQStashDev();
+ *   startDevServer();
  * }
  * ```
  */
 export async function registerQStashDev(): Promise<void> {
-  // Production — dev server should never run.
-  // (Edge-runtime gating happens inside ensureDevelopmentServer → getRuntime;
-  // referencing process.release directly here trips Next.js's edge analyzer.)
-  if (process.env.NODE_ENV === "production") return;
-  // next build — NEXT_RUNTIME is set to "nodejs" during build too,
-  // but NEXT_PHASE tells us if we're building
-  if (process.env.NEXT_PHASE === "phase-production-build") return;
-
-  await ensureDevelopmentServer(undefined, true);
+  await startDevServer();
 }

--- a/platforms/nextjs.ts
+++ b/platforms/nextjs.ts
@@ -298,8 +298,8 @@ export const servePagesRouter = <TInitialPayload = unknown>(
  * // instrumentation.ts
  * import { startDevServer } from "@upstash/qstash";
  *
- * export function register() {
- *   startDevServer();
+ * export async function register() {
+ *   await startDevServer();
  * }
  * ```
  */

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -24,7 +24,7 @@ import { processApi } from "./api/utils";
 import { VERSION } from "../../version";
 import { getClientCredentials } from "./multi-region";
 
-import { shouldUseDevelopmentMode, ensureDevelopmentServer } from "../dev-server";
+import { shouldUseDevelopmentMode, ensureDevelopmentServer, DEV_PREFIX } from "../dev-server";
 
 type ClientConfig = {
   /**
@@ -391,7 +391,9 @@ export class Client {
 
     // Fire-and-forget dev server startup
     if (shouldUseDevelopmentMode(config?.devMode, environment)) {
-      void ensureDevelopmentServer(environment, config?.devMode);
+      ensureDevelopmentServer(environment, config?.devMode).catch((error: unknown) => {
+        console.warn(`${DEV_PREFIX} Could not start dev server:`, error);
+      });
     }
 
     const enableTelemetry = environment.UPSTASH_DISABLE_TELEMETRY

--- a/src/dev-server/binary.ts
+++ b/src/dev-server/binary.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 import {
+  ARTIFACTS_LIST_URL,
   BINARY_URL_BASE,
   DEV_PREFIX,
-  GITHUB_RELEASES_URL,
   importFs,
   importChildProcess,
   importOs,
@@ -41,17 +41,42 @@ export const ensureBinary = async (): Promise<string> => {
 };
 
 const fetchLatestVersion = async (): Promise<string> => {
-  const { ok, statusCode, body } = await nativeGet(GITHUB_RELEASES_URL, {
-    Accept: "application/vnd.github.v3+json",
-    "User-Agent": "upstash-qstash-js",
-  });
+  const { ok, statusCode, body } = await nativeGet(ARTIFACTS_LIST_URL);
 
   if (!ok) {
     throw new Error(`[QStash Dev] Failed to fetch latest version: HTTP ${statusCode}`);
   }
 
-  const data = JSON.parse(body.toString()) as { tag_name: string };
-  return data.tag_name.replace(/^v/, "");
+  // Parse <CommonPrefixes><Prefix>qstash/versions/X.Y.Z/</Prefix></CommonPrefixes>
+  const xml = body.toString();
+  const versions: string[] = [];
+  const re = /<Prefix>qstash\/versions\/([^/<]+)\/<\/Prefix>/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(xml)) !== null) {
+    const v = match[1];
+    // Skip pre-releases (e.g. 2.20.7-rc.1). Only stable X.Y.Z.
+    if (/^\d+\.\d+\.\d+$/.test(v)) versions.push(v);
+  }
+
+  if (versions.length === 0) {
+    throw new Error("[QStash Dev] No stable versions found in artifact bucket");
+  }
+
+  versions.sort(compareSemver);
+  const latest = versions.at(-1);
+  if (!latest) {
+    throw new Error("[QStash Dev] No stable versions found in artifact bucket");
+  }
+  return latest;
+};
+
+const compareSemver = (a: string, b: string): number => {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (const [index, part] of pa.entries()) {
+    if (part !== pb[index]) return part - pb[index];
+  }
+  return 0;
 };
 
 const findCacheDirectory = async (): Promise<string> => {

--- a/src/dev-server/constants.ts
+++ b/src/dev-server/constants.ts
@@ -8,9 +8,11 @@ export const DEV_CREDENTIALS = {
   nextSigningKey: "sig_5ZB6DVzB1wjE8S6rZ7eenA8Pdnhs",
 };
 
-export const GITHUB_RELEASES_URL =
-  "https://api.github.com/repos/upstash/qstash-cli/releases/latest";
 export const BINARY_URL_BASE = "https://artifacts.upstash.com/qstash/versions";
+// S3 list endpoint for the same bucket. Used to discover the latest version
+// without hitting GitHub's rate-limited unauthenticated API.
+export const ARTIFACTS_LIST_URL =
+  "https://s3.eu-central-1.amazonaws.com/artifacts.upstash.com/?prefix=qstash/versions/&delimiter=/";
 export const CONSOLE_URL = "https://console.upstash.com/qstash/local-mode-user";
 
 // Dim ANSI prefixes for console output. SDK-emitted lines use [QStash Dev];

--- a/src/dev-server/health.ts
+++ b/src/dev-server/health.ts
@@ -81,8 +81,8 @@ const unreachableMessage = (baseUrl: string, runtime?: Runtime): string => {
     `Either:\n` +
     `  1. Add the instrumentation hook to start it with your app:\n\n` +
     `     // instrumentation.ts\n` +
-    `     import { registerQStashDev } from "@upstash/qstash/nextjs";\n` +
-    `     export async function register() { await registerQStashDev(); }\n\n` +
+    `     import { startDevServer } from "@upstash/qstash";\n` +
+    `     export async function register() { await startDevServer(); }\n\n` +
     `  2. Or start it manually:\n\n` +
     `     ${manualStartCmd}\n`
   );

--- a/src/dev-server/index.test.ts
+++ b/src/dev-server/index.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll, spyOn } from "bun:test";
 import { Client } from "../client/client";
+import * as health from "./health";
 import { getClientCredentials } from "../client/multi-region/outgoing";
 import { getReceiverSigningKeys } from "../client/multi-region/incoming";
 import {
@@ -9,7 +10,7 @@ import {
   getRuntime,
   getDevelopmentCredentials,
   ensureDevelopmentServer,
-  stopDevelopmentServer,
+  stopDevServer,
 } from "./index";
 import { DEV_CREDENTIALS, DEFAULT_DEV_PORT } from "./constants";
 
@@ -151,21 +152,29 @@ describe("ensureDevelopmentServer", () => {
     await ensureDevelopmentServer({}, undefined);
   });
 
-  test("returns singleton promise on repeated calls", async () => {
-    const p1 = ensureDevelopmentServer(undefined, true);
-    const p2 = ensureDevelopmentServer(undefined, true);
-    expect(p1).toBe(p2);
-    // Await so the spawn actually finishes before afterAll tries to stop it,
-    // otherwise the child registers after stopDevelopmentServer is a no-op
-    // and the binary is left running on the default port.
-    await p1;
+  test("dedupes concurrent calls into a single startup", async () => {
+    stopDevServer(); // reset the singleton so this test owns the startup
+    // isDevServerRunning is the first step of the (singleton) startup pipeline,
+    // so sharing the singleton means it runs exactly once across both calls.
+    const runningSpy = spyOn(health, "isDevServerRunning");
+    try {
+      const p1 = ensureDevelopmentServer(undefined, true);
+      const p2 = ensureDevelopmentServer(undefined, true);
+      // Await so the spawn actually finishes before afterAll tries to stop it,
+      // otherwise the child registers after stopDevServer is a no-op and the
+      // binary is left running on the default port.
+      await Promise.all([p1, p2]);
+      expect(runningSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      runningSpy.mockRestore();
+    }
   });
 
   // The singleton-promise test above actually spawns the dev binary on the
   // default port. Stop it so the integration block below can rebind on a
   // non-default port and so other test files don't inherit a held 8080.
   afterAll(() => {
-    stopDevelopmentServer();
+    stopDevServer();
   });
 });
 
@@ -231,7 +240,7 @@ describe("dev server integration", () => {
   afterAll(() => {
     // Kill the spawned binary so it doesn't hold the port for the rest of the
     // test process (workflow test-utils and others bind 8080 / would race here).
-    stopDevelopmentServer();
+    stopDevServer();
     if (savedPort === undefined) delete process.env.QSTASH_DEV_PORT;
     else process.env.QSTASH_DEV_PORT = savedPort;
   });

--- a/src/dev-server/index.ts
+++ b/src/dev-server/index.ts
@@ -32,28 +32,31 @@ let devServerPromise: Promise<void> | undefined;
  *
  * @param devMode - Explicit override: `true` forces on, `false` forces off, `undefined` checks env
  */
-export const ensureDevelopmentServer = (
+export const ensureDevelopmentServer = async (
   env: Record<string, string | undefined> | undefined,
   devMode: boolean | undefined
 ): Promise<void> => {
-  if (!shouldUseDevelopmentMode(devMode, env)) return Promise.resolve();
+  if (!shouldUseDevelopmentMode(devMode, env)) return;
 
   // Don't spawn during a build (`next build`, etc.) — the route module may be
   // evaluated at build time but the dev binary should only run in `next dev`.
   // Also short-circuit in production so an accidental devMode: true in prod
   // doesn't try to download a binary.
   const procEnv = _processGlobal()?.env;
-  if (procEnv?.NEXT_PHASE === "phase-production-build") return Promise.resolve();
-  if (procEnv?.NODE_ENV === "production") return Promise.resolve();
+  if (procEnv?.NEXT_PHASE === "phase-production-build") return;
+  if (procEnv?.NODE_ENV === "production") return;
 
   const runtime = getRuntime();
 
   // Edge/browser can't spawn processes, just verify the server is reachable
   // so the user gets a helpful error instead of a generic "fetch failed".
   if (runtime !== "nodejs") {
-    return checkDevServerReachable(getDevUrl(env), runtime);
+    await checkDevServerReachable(getDevUrl(env), runtime);
+    return;
   }
 
+  // Share a single startup across all callers; drop it on failure so a later
+  // call (e.g. a real publish request) retries and can surface the error.
   if (!devServerPromise) {
     devServerPromise = startPipeline(env).catch((error: unknown) => {
       devServerPromise = undefined;
@@ -61,15 +64,41 @@ export const ensureDevelopmentServer = (
     });
   }
 
-  return devServerPromise;
+  await devServerPromise;
 };
 
 /**
- * Stop the spawned dev server (if any) and reset the singleton so a future
- * call to {@link ensureDevelopmentServer} starts a fresh process. Intended
- * for tests that need to release the port between runs.
+ * Starts the local QStash dev server when `QSTASH_DEV` is `1`/`true` (otherwise
+ * does nothing).
+ *
+ * You usually don't need this: the dev server also starts automatically when you
+ * construct a `Client` or send a publish request. Call it only when you want to
+ * start it manually up front — e.g. from a script or a Next.js
+ * `instrumentation.ts` hook.
+ *
+ * Never throws; if the server can't start it logs a `[QStash Dev]` warning.
+ *
+ * @example
+ * ```ts
+ * import { startDevServer } from "@upstash/qstash";
+ * await startDevServer();
+ * ```
  */
-export const stopDevelopmentServer = (): void => {
+export const startDevServer = async (): Promise<void> => {
+  try {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    await ensureDevelopmentServer(undefined, undefined);
+  } catch (error) {
+    console.warn(`${DEV_PREFIX} Could not start dev server:`, error);
+  }
+};
+
+/**
+ * Internal test helper (not part of the public API): stop the spawned dev
+ * server, if any, and reset the singleton so the next start spawns fresh.
+ * Lets tests release the port between runs.
+ */
+export const stopDevServer = (): void => {
   stopCurrentServer();
   devServerPromise = undefined;
 };

--- a/src/dev-server/index.ts
+++ b/src/dev-server/index.ts
@@ -23,12 +23,17 @@ const _processGlobal = (): ProcessLike | undefined => {
 let devServerPromise: Promise<void> | undefined;
 
 /**
- * Ensure the dev server is running. Returns a singleton promise
- * that resolves once the server is ready.
+ * Ensure the dev server is running, resolving once it's ready.
  *
- * No-op when:
- * - `typeof process === "undefined"` (edge/browser)
- * - dev mode is not enabled
+ * Concurrent callers (Client, HttpClient, etc.) share a single startup:
+ * the spawn is deduped internally via a shared promise, so only one binary
+ * is launched even though each call returns its own promise awaiting it.
+ *
+ * Behaviour by situation:
+ * - dev mode not enabled, `next build`, or production → no-op
+ * - Node.js runtime → downloads (if needed) and spawns the dev binary
+ * - edge/browser/Cloudflare (can't spawn a process) → only verifies the
+ *   server is reachable, throwing a helpful error if it isn't
  *
  * @param devMode - Explicit override: `true` forces on, `false` forces off, `undefined` checks env
  */

--- a/src/dev-server/start-dev-server.test.ts
+++ b/src/dev-server/start-dev-server.test.ts
@@ -1,0 +1,233 @@
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { describe, test, expect, beforeAll, afterAll, spyOn } from "bun:test";
+
+import * as binary from "./binary";
+import { ensureDevelopmentServer, startDevServer, stopDevServer } from "./index";
+import { Client } from "../client/client";
+
+// We make the spawn pipeline fail deterministically and WITHOUT network access
+// by spying on `ensureBinary` (the first network/IO step) and forcing it to
+// reject. `index.ts` calls it through the live module binding, so the spy
+// intercepts it. Each test installs and restores its own spy, so nothing leaks
+// into other test files (unlike a process-global `mock.module`).
+const SPAWN_ERROR = "[QStash Dev] forced spawn failure (test)";
+const failBinary = () => spyOn(binary, "ensureBinary").mockRejectedValue(new Error(SPAWN_ERROR));
+
+// Run on a free port so isDevServerRunning() is false and the pipeline reaches
+// the (spied, failing) ensureBinary step instead of short-circuiting.
+const FREE_PORT = "8585";
+
+const savedToken = process.env.QSTASH_TOKEN;
+const savedCurrentKey = process.env.QSTASH_CURRENT_SIGNING_KEY;
+const savedNextKey = process.env.QSTASH_NEXT_SIGNING_KEY;
+const savedPort = process.env.QSTASH_DEV_PORT;
+const savedDev = process.env.QSTASH_DEV;
+const savedNodeEnv = process.env.NODE_ENV;
+const savedPhase = process.env.NEXT_PHASE;
+
+const restoreEnv = (key: string, value: string | undefined) => {
+  if (value === undefined) Reflect.deleteProperty(process.env, key);
+  else process.env[key] = value;
+};
+
+beforeAll(() => {
+  delete process.env.QSTASH_TOKEN;
+  delete process.env.QSTASH_CURRENT_SIGNING_KEY;
+  delete process.env.QSTASH_NEXT_SIGNING_KEY;
+  process.env.QSTASH_DEV_PORT = FREE_PORT;
+});
+
+afterAll(() => {
+  stopDevServer();
+  restoreEnv("QSTASH_TOKEN", savedToken);
+  restoreEnv("QSTASH_CURRENT_SIGNING_KEY", savedCurrentKey);
+  restoreEnv("QSTASH_NEXT_SIGNING_KEY", savedNextKey);
+  restoreEnv("QSTASH_DEV_PORT", savedPort);
+  restoreEnv("QSTASH_DEV", savedDev);
+  restoreEnv("NODE_ENV", savedNodeEnv);
+  restoreEnv("NEXT_PHASE", savedPhase);
+});
+
+const withEnv = async (
+  overrides: Record<string, string | undefined>,
+  function_: () => Promise<void>
+) => {
+  const previous: Record<string, string | undefined> = {};
+  for (const key of Object.keys(overrides)) {
+    previous[key] = process.env[key];
+    restoreEnv(key, overrides[key]);
+  }
+  try {
+    await function_();
+  } finally {
+    for (const key of Object.keys(previous)) restoreEnv(key, previous[key]);
+  }
+};
+
+// ── ensureDevelopmentServer: precise-error contract ─────────────────────
+
+describe("ensureDevelopmentServer (precise-error contract)", () => {
+  test("rejects on spawn failure", async () => {
+    stopDevServer();
+    const spy = failBinary();
+    try {
+      const promise = ensureDevelopmentServer(undefined, true);
+      // Catch first so the rejection is handled, then assert it rejected.
+      const caught = await promise.then(
+        () => {},
+        (error: unknown) => error
+      );
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toBe(SPAWN_ERROR);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("resets its singleton after a failed spawn so a later call retries", async () => {
+    stopDevServer();
+    const spy = failBinary();
+    try {
+      // Both calls must reject; the second proves the singleton was reset (the
+      // pipeline ran ensureBinary again) rather than returning a cached
+      // rejected promise. We assert ensureBinary was called twice.
+      const swallow = (error: unknown) => error;
+      const firstError = await ensureDevelopmentServer(undefined, true).then(() => {}, swallow);
+      const secondError = await ensureDevelopmentServer(undefined, true).then(() => {}, swallow);
+      expect(firstError).toBeInstanceOf(Error);
+      expect(secondError).toBeInstanceOf(Error);
+      expect(spy).toHaveBeenCalledTimes(2);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+// ── startDevServer: public boundary never throws ────────────────────────
+
+describe("startDevServer (public boundary)", () => {
+  test("resolves and warns when the spawn fails (does not throw)", async () => {
+    stopDevServer();
+    const spy = failBinary();
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await withEnv(
+        { QSTASH_DEV: "true", NODE_ENV: undefined, NEXT_PHASE: undefined },
+        async () => {
+          // Must resolve even though ensureDevelopmentServer rejects.
+          await startDevServer();
+        }
+      );
+      expect(warnSpy).toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const firstArgument: unknown = warnSpy.mock.calls[0]?.[0];
+      expect(String(firstArgument)).toContain("Could not start dev server");
+    } finally {
+      warnSpy.mockRestore();
+      spy.mockRestore();
+    }
+  });
+
+  test("resolves (does not throw) when QSTASH_DEV is malformed", async () => {
+    stopDevServer();
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await withEnv(
+        { QSTASH_DEV: "totally-bogus", NODE_ENV: undefined, NEXT_PHASE: undefined },
+        async () => {
+          // shouldUseDevelopmentMode throws internally; startDevServer must swallow it.
+          await startDevServer();
+        }
+      );
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("no-op when QSTASH_DEV is unset", async () => {
+    const spy = failBinary();
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await withEnv({ QSTASH_DEV: undefined, NODE_ENV: undefined, NEXT_PHASE: undefined }, () =>
+        startDevServer()
+      );
+      // Gated off → ensureBinary never reached, no "could not start" warning.
+      expect(spy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      spy.mockRestore();
+    }
+  });
+
+  test("no-op in production (NODE_ENV=production)", async () => {
+    const spy = failBinary();
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await withEnv({ QSTASH_DEV: "true", NODE_ENV: "production", NEXT_PHASE: undefined }, () =>
+        startDevServer()
+      );
+      expect(spy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      spy.mockRestore();
+    }
+  });
+
+  test("no-op during build (NEXT_PHASE=phase-production-build)", async () => {
+    const spy = failBinary();
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await withEnv(
+        { QSTASH_DEV: "true", NODE_ENV: undefined, NEXT_PHASE: "phase-production-build" },
+        () => startDevServer()
+      );
+      expect(spy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      spy.mockRestore();
+    }
+  });
+});
+
+// ── Client fire-and-forget: no unhandled rejection ──────────────────────
+
+describe("Client fire-and-forget dev-server start", () => {
+  test("constructing a Client whose dev-server start fails does not produce an unhandled rejection", async () => {
+    stopDevServer();
+    const spy = failBinary();
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      await withEnv(
+        { QSTASH_DEV: "true", NODE_ENV: undefined, NEXT_PHASE: undefined },
+        async () => {
+          // Constructor calls ensureDevelopmentServer(...).catch(...); the spied
+          // ensureBinary makes that promise reject. The .catch must absorb it.
+          // eslint-disable-next-line no-new
+          new Client({ devMode: true });
+          // Let the rejected promise settle; without the .catch the rejection
+          // would surface as unhandledRejection within a few ticks.
+          await new Promise((resolve) => setTimeout(resolve, 300));
+        }
+      );
+      expect(unhandled).toHaveLength(0);
+      // The catch logs a warning instead of silently swallowing.
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      warnSpy.mockRestore();
+      spy.mockRestore();
+      stopDevServer();
+    }
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,5 @@ export * from "./client/llm/chat";
 export * from "./client/llm/types";
 export * from "./client/llm/providers";
 export * from "./client/api";
+
+export { startDevServer } from "./dev-server";


### PR DESCRIPTION
## Summary

Lands the evolved QStash dev-server work on top of current `main`.

- Export a public `startDevServer` from `@upstash/qstash` (`stopDevServer` stays internal).
- `Client` constructor now warns (instead of silently swallowing) when the fire-and-forget dev-server startup fails.
- Dev-server binary discovery now uses S3 artifacts and adds Windows support.
- `registerQStashDev` (`@upstash/qstash/nextjs`) is demoted to a deprecated, back-compat alias that delegates to `startDevServer`.
- Shortened docstrings + new `start-dev-server` test coverage.

## Notes

- Branched off `origin/main` (a rebase of the original messy branch was impossible since an earlier predecessor was already squash-merged via #262).
- The dev-server module was taken wholesale from the evolved commit; main's only post-#262 dev-server change (#266's `health.ts` lint tweak) is already present.
- main's unrelated `label?: string | string[]` change (#266) on the client is preserved.

## Testing

- Verified end-to-end on **Windows 11 (x64, Node 22)**: the dev server downloads the Windows binary, extracts it via `tar`, spawns `qstash.exe`, serves `/v2/keys` with the expected dev signing keys, and accepts a publish — all green. (CI itself still runs Linux-only.)
