### PR TITLE
feat: multi-value filters for bulk message cancel + multi-label schedules

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -7,7 +7,7 @@ import { Client } from "./client";
 import type { PublishToUrlResponse } from "../../dist";
 import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
 import type { HttpClient } from "./http";
-import { eventually } from "./logs.test";
+import { eventually } from "./test-utils";
 
 export const clearQueues = async (client: Client) => {
   const queueDetails = await client.queue().list();

--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -206,25 +206,28 @@ describe("DLQ", () => {
     async () => {
       const testLabel = `dlq-test-label-${Date.now()}`;
       await client.publish({
-        url: `https://httpbin.org/status/400`, // Any broken link will work
+        url: `https://example.com/${testLabel}`, // Any broken link will work
         retries: 0,
         label: testLabel,
       });
 
-      await sleep(4000);
+      await eventually(
+        async () => {
+          const dlqLogs = await client.dlq.listMessages({
+            filter: {
+              label: testLabel,
+            },
+          });
 
-      const dlqLogs = await client.dlq.listMessages({
-        filter: {
-          label: testLabel,
+          expect(dlqLogs.messages.length).toBeGreaterThanOrEqual(1);
+          for (const message of dlqLogs.messages) {
+            if (message.label !== undefined) {
+              expect(message.label).toBe(testLabel);
+            }
+          }
         },
-      });
-
-      expect(dlqLogs.messages.length).toBeGreaterThanOrEqual(1);
-      for (const message of dlqLogs.messages) {
-        if (message.label !== undefined) {
-          expect(message.label).toBe(testLabel);
-        }
-      }
+        { timeout: 15_000, interval: 1000 }
+      );
     },
     { timeout: 20_000 }
   );
@@ -236,7 +239,7 @@ describe("DLQ", () => {
       const labelTwo = `dlq-multi-b-${Date.now()}`;
 
       const { messageId } = await client.publish({
-        url: `https://httpbin.org/status/400`, // Any broken link will work
+        url: `https://example.com/${labelOne}`, // Any broken link will work
         retries: 0,
         label: [labelOne, labelTwo],
       });
@@ -271,17 +274,17 @@ describe("DLQ", () => {
 
       // msg1: [A, B], msg2: [B, C], msg3: [C]
       const { messageId: messageAB } = await client.publish({
-        url: `https://httpbin.org/status/400`,
+        url: `https://example.com/${labelA}`,
         retries: 0,
         label: [labelA, labelB],
       });
       const { messageId: messageBC } = await client.publish({
-        url: `https://httpbin.org/status/400`,
+        url: `https://example.com/${labelB}`,
         retries: 0,
         label: [labelB, labelC],
       });
       const { messageId: messageC } = await client.publish({
-        url: `https://httpbin.org/status/400`,
+        url: `https://example.com/${labelC}`,
         retries: 0,
         label: labelC,
       });

--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -164,7 +164,7 @@ describe("DLQ", () => {
       const retryDelay = "2000 * retried";
       const randomKey = `flow-control-key-${Date.now()}`;
       const { messageId } = await client.publish({
-        url: "https://httpbin.org/status/400",
+        url: `https://example.com/${randomKey}`,
         body: "hello",
         retries: 0,
         flowControl: {
@@ -814,7 +814,7 @@ describe("DLQ", () => {
     async () => {
       const flowKey = `dlq-flow-key-${Date.now()}`;
       await client.publish({
-        url: "https://httpbin.org/status/400",
+        url: `https://example.com/${flowKey}`,
         body: "hello",
         retries: 0,
         flowControl: {

--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -1095,9 +1095,9 @@ describe("DLQ - mocked filter url shape", () => {
         url: `${MOCK_QSTASH_SERVER_URL}/v2/dlq?url=${encodeURIComponent("https://a.com")}&url=${encodeURIComponent("https://b.com")}&flowControlKey=key-1&flowControlKey=key-2`,
       },
       validateRequest: (request) => {
-        const params = new URL(request.url).searchParams;
-        expect(params.getAll("url")).toEqual(["https://a.com", "https://b.com"]);
-        expect(params.getAll("flowControlKey")).toEqual(["key-1", "key-2"]);
+        const parameters = new URL(request.url).searchParams;
+        expect(parameters.getAll("url")).toEqual(["https://a.com", "https://b.com"]);
+        expect(parameters.getAll("flowControlKey")).toEqual(["key-1", "key-2"]);
       },
     });
   });

--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -5,7 +5,7 @@
 import { sleep } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Client } from "./client";
-import { eventually } from "./logs.test";
+import { eventually } from "./test-utils";
 import { MOCK_QSTASH_SERVER_URL, mockQStashServer, expectToReject } from "./workflow/test-utils";
 import type { HttpClient } from "./http";
 

--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -241,18 +241,21 @@ describe("DLQ", () => {
         label: [labelOne, labelTwo],
       });
 
-      await sleep(4000);
+      await eventually(
+        async () => {
+          const dlqLogs = await client.dlq.listMessages({
+            filter: { label: [labelOne, labelTwo] },
+          });
 
-      const dlqLogs = await client.dlq.listMessages({
-        filter: { label: [labelOne, labelTwo] },
-      });
-
-      const message = dlqLogs.messages.find((m) => m.messageId === messageId);
-      expect(message).toBeDefined();
-      // legacy `label` carries only the first label
-      expect(message!.label).toBe(labelOne);
-      // new `labels` carries all of them
-      expect(message!.labels).toEqual([labelOne, labelTwo]);
+          const message = dlqLogs.messages.find((m) => m.messageId === messageId);
+          expect(message).toBeDefined();
+          // legacy `label` carries only the first label
+          expect(message!.label).toBe(labelOne);
+          // new `labels` carries all of them
+          expect(message!.labels).toEqual([labelOne, labelTwo]);
+        },
+        { timeout: 15_000, interval: 1000 }
+      );
 
       await client.dlq.delete({ filter: { label: [labelOne, labelTwo] } });
     },
@@ -283,7 +286,17 @@ describe("DLQ", () => {
         label: labelC,
       });
 
-      await sleep(4000);
+      // wait for all three to land in the DLQ
+      await eventually(
+        async () => {
+          const all = await client.dlq.listMessages({
+            filter: { label: [labelA, labelB, labelC] },
+          });
+          const allIds = new Set(all.messages.map((m) => m.messageId));
+          expect(allIds.has(messageAB) && allIds.has(messageBC) && allIds.has(messageC)).toBe(true);
+        },
+        { timeout: 15_000, interval: 1000 }
+      );
 
       // filtering by [A, B] should match msgAB and msgBC (both share a label)
       // but NOT msgC.

--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -298,6 +298,40 @@ describe("DLQ", () => {
   );
 
   test(
+    "should filter DLQ messages by multiple urls (OR semantics)",
+    async () => {
+      const stamp = Date.now();
+      const urlA = `https://example.com/dlq-url-a-${stamp}`;
+      const urlB = `https://example.com/dlq-url-b-${stamp}`;
+      const urlC = `https://example.com/dlq-url-c-${stamp}`;
+
+      const { messageId: idA } = await client.publish({ url: urlA, retries: 0 });
+      const { messageId: idB } = await client.publish({ url: urlB, retries: 0 });
+      const { messageId: idC } = await client.publish({ url: urlC, retries: 0 });
+
+      // wait for all three to land in the DLQ
+      await eventually(
+        async () => {
+          const all = await client.dlq.listMessages({ filter: { url: [urlA, urlB, urlC] } });
+          const ids = new Set(all.messages.map((m) => m.messageId));
+          expect(ids.has(idA) && ids.has(idB) && ids.has(idC)).toBe(true);
+        },
+        { timeout: 15_000, interval: 1000 }
+      );
+
+      // filtering by [A, B] should match A and B but NOT C.
+      const result = await client.dlq.listMessages({ filter: { url: [urlA, urlB] } });
+      const ids = new Set(result.messages.map((m) => m.messageId));
+      expect(ids.has(idA)).toBe(true);
+      expect(ids.has(idB)).toBe(true);
+      expect(ids.has(idC)).toBe(false);
+
+      await client.dlq.delete({ filter: { url: [urlA, urlB, urlC] } });
+    },
+    { timeout: 25_000 }
+  );
+
+  test(
     "should retry multiple messages from DLQ",
     async () => {
       // Publish multiple messages that will fail
@@ -1036,6 +1070,31 @@ describe("DLQ - mocked filter url shape", () => {
       },
       validateRequest: (request) => {
         expect(new URL(request.url).searchParams.getAll("label")).toEqual(["label-1", "label-2"]);
+      },
+    });
+  });
+
+  test("should send multi-value url and flowControlKey as repeated query params", async () => {
+    const mockClient = new Client({ token, baseUrl: MOCK_QSTASH_SERVER_URL });
+    await mockQStashServer({
+      execute: async () => {
+        await mockClient.dlq.listMessages({
+          filter: {
+            url: ["https://a.com", "https://b.com"],
+            flowControlKey: ["key-1", "key-2"],
+          },
+        });
+      },
+      responseFields: { body: { messages: [] }, status: 200 },
+      receivesRequest: {
+        method: "GET",
+        token,
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/dlq?url=${encodeURIComponent("https://a.com")}&url=${encodeURIComponent("https://b.com")}&flowControlKey=key-1&flowControlKey=key-2`,
+      },
+      validateRequest: (request) => {
+        const params = new URL(request.url).searchParams;
+        expect(params.getAll("url")).toEqual(["https://a.com", "https://b.com"]);
+        expect(params.getAll("flowControlKey")).toEqual(["key-1", "key-2"]);
       },
     });
   });

--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -176,25 +176,28 @@ describe("DLQ", () => {
         retryDelay,
       });
 
-      await eventually(async () => {
-        const result = await client.dlq.listMessages({
-          filter: {
-            messageId,
-          },
-        });
-        expect(result.messages.length).toBe(1);
-        const message = result.messages[0];
+      await eventually(
+        async () => {
+          const result = await client.dlq.listMessages({
+            filter: {
+              messageId,
+            },
+          });
+          expect(result.messages.length).toBe(1);
+          const message = result.messages[0];
 
-        expect(message.flowControlKey).toBe(randomKey);
-        expect(message.parallelism).toBe(parallelism);
-        expect(message.ratePerSecond).toBe(ratePerSecond);
-        expect(message.rate).toBe(ratePerSecond);
-        expect(message.period).toBe(SECONDS_IN_A_DAY);
-        expect(message.retryDelayExpression).toBe(retryDelay);
-      });
+          expect(message.flowControlKey).toBe(randomKey);
+          expect(message.parallelism).toBe(parallelism);
+          expect(message.ratePerSecond).toBe(ratePerSecond);
+          expect(message.rate).toBe(ratePerSecond);
+          expect(message.period).toBe(SECONDS_IN_A_DAY);
+          expect(message.retryDelayExpression).toBe(retryDelay);
+        },
+        { timeout: 25_000, interval: 1000 }
+      );
     },
     {
-      timeout: 10_000,
+      timeout: 30_000,
     }
   );
 

--- a/src/client/filter-types.ts
+++ b/src/client/filter-types.ts
@@ -57,7 +57,34 @@ type DLQFilterFields = UniversalFilterFields &
     api?: string;
   };
 
-type MessageCancelFilterFields = UniversalFilterFields & Omit<QStashIdentityFields, "messageId">;
+/**
+ * Filter fields for the bulk message cancel endpoint.
+ *
+ * Unlike the DLQ and logs endpoints, bulk cancel supports multi-value filtering:
+ * a message matches if its value equals any of the given values (OR logic), and
+ * separate filters are combined with AND logic. Pass an array to match any value.
+ */
+type MessageCancelFilterFields = Omit<
+  UniversalFilterFields & Omit<QStashIdentityFields, "messageId">,
+  "callerIp" | "flowControlKey" | "url" | "urlGroup" | "scheduleId" | "queueName"
+> & {
+  /** Filter by the IP address of the publisher. Supports multiple values. */
+  callerIp?: string | string[];
+  /** Filter by Flow Control Key. Supports multiple values. */
+  flowControlKey?: string | string[];
+  /** Filter by destination URL. Supports multiple values. */
+  url?: string | string[];
+  /** Filter by URL Group name. Supports multiple values. */
+  urlGroup?: string | string[];
+  /** Filter by Schedule ID. Supports multiple values. */
+  scheduleId?: string | string[];
+  /** Filter by Queue name. Supports multiple values. */
+  queueName?: string | string[];
+  /** Filter by the host of the destination URL. Supports multiple values. */
+  host?: string | string[];
+  /** Filter by the path of the destination URL. Supports multiple values. */
+  path?: string | string[];
+};
 
 // ── QStash Composed Endpoint Filter Types ─────────────────────
 

--- a/src/client/filter-types.ts
+++ b/src/client/filter-types.ts
@@ -11,11 +11,18 @@ type Exclusive<A, B> = (A & NeverKeys<B>) | (B & NeverKeys<A>);
 
 // ── Filter Field Groups ───────────────────────────────────────
 
-/** Shared filter fields accepted by every qstash & workflow endpoint. */
+/**
+ * Shared filter fields accepted by every qstash & workflow endpoint.
+ *
+ * Most fields support multi-value filtering: pass an array to match a record
+ * whose value equals any of the given values (OR semantics). Separate filters
+ * are combined with AND semantics.
+ */
 type UniversalFilterFields = {
   fromDate?: Date | number;
   toDate?: Date | number;
-  callerIp?: string;
+  /** Filter by the IP address of the publisher. Supports multiple values. */
+  callerIp?: string | string[];
   /**
    * Filter by label.
    *
@@ -24,16 +31,26 @@ type UniversalFilterFields = {
    * filtering by `[label_1, label_2]` returns both.
    */
   label?: string | string[];
-  flowControlKey?: string;
+  /** Filter by Flow Control Key. Supports multiple values. */
+  flowControlKey?: string | string[];
 };
 
-/** QStash-specific identity filters (DLQ + message endpoints). */
+/**
+ * QStash-specific identity filters (DLQ + message endpoints).
+ *
+ * Every field except `messageId` supports multi-value filtering: pass an array
+ * to match a record whose value equals any of the given values (OR semantics).
+ */
 type QStashIdentityFields = {
   messageId?: string;
-  url?: string;
-  urlGroup?: string;
-  scheduleId?: string;
-  queueName?: string;
+  /** Filter by destination URL. Supports multiple values. */
+  url?: string | string[];
+  /** Filter by URL Group name. Supports multiple values. */
+  urlGroup?: string | string[];
+  /** Filter by Schedule ID. Supports multiple values. */
+  scheduleId?: string | string[];
+  /** Filter by Queue name. Supports multiple values. */
+  queueName?: string | string[];
 };
 
 /** DLQ-specific response filter. */
@@ -44,6 +61,19 @@ type DLQResponseFields = {
 /** Logs-specific filter fields exclusive to log endpoints. */
 type LogsFilterFields = {
   state?: State;
+};
+
+/**
+ * Filter by the host/path of the destination URL.
+ *
+ * Supported by the message cancel and logs endpoints (the DLQ endpoint rejects
+ * these). Each supports multiple values: pass an array to match any value.
+ */
+type HostPathFilterFields = {
+  /** Filter by the host of the destination URL. Supports multiple values. */
+  host?: string | string[];
+  /** Filter by the path of the destination URL. Supports multiple values. */
+  path?: string | string[];
 };
 
 // ── Composed Filter Field Types ───────────────────────────────
@@ -60,31 +90,12 @@ type DLQFilterFields = UniversalFilterFields &
 /**
  * Filter fields for the bulk message cancel endpoint.
  *
- * Unlike the DLQ and logs endpoints, bulk cancel supports multi-value filtering:
- * a message matches if its value equals any of the given values (OR logic), and
- * separate filters are combined with AND logic. Pass an array to match any value.
+ * Inherits the shared multi-value fields plus the `host`/`path` destination
+ * filters (also supported by logs).
  */
-type MessageCancelFilterFields = Omit<
-  UniversalFilterFields & Omit<QStashIdentityFields, "messageId">,
-  "callerIp" | "flowControlKey" | "url" | "urlGroup" | "scheduleId" | "queueName"
-> & {
-  /** Filter by the IP address of the publisher. Supports multiple values. */
-  callerIp?: string | string[];
-  /** Filter by Flow Control Key. Supports multiple values. */
-  flowControlKey?: string | string[];
-  /** Filter by destination URL. Supports multiple values. */
-  url?: string | string[];
-  /** Filter by URL Group name. Supports multiple values. */
-  urlGroup?: string | string[];
-  /** Filter by Schedule ID. Supports multiple values. */
-  scheduleId?: string | string[];
-  /** Filter by Queue name. Supports multiple values. */
-  queueName?: string | string[];
-  /** Filter by the host of the destination URL. Supports multiple values. */
-  host?: string | string[];
-  /** Filter by the path of the destination URL. Supports multiple values. */
-  path?: string | string[];
-};
+type MessageCancelFilterFields = UniversalFilterFields &
+  Omit<QStashIdentityFields, "messageId"> &
+  HostPathFilterFields;
 
 // ── QStash Composed Endpoint Filter Types ─────────────────────
 
@@ -158,6 +169,7 @@ export type LogsListRequest = Exclusive<
 
 export type LogsListFilters = UniversalFilterFields &
   Omit<QStashIdentityFields, "messageId"> &
+  HostPathFilterFields &
   LogsFilterFields & {
     /**
      * @deprecated `api` filter has been removed from the API and will be ignored

--- a/src/client/flow-control.test.ts
+++ b/src/client/flow-control.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, test } from "bun:test";
 import { Client } from "./client";
 import { MOCK_QSTASH_SERVER_URL, mockQStashServer, expectToReject } from "./workflow/test-utils";
+import { eventually } from "./logs.test";
 
 describe("FlowControl empty id guard", () => {
   test("should not send request when get is called with an empty string", async () => {
@@ -213,8 +214,13 @@ describe("FlowControl", () => {
       await client.flowControl.resetRate(flowControlKey);
 
       // Verify rate was reset by checking the flow control info
-      const info = await client.flowControl.get(flowControlKey);
-      expect(info.rateCount).toBe(0);
+      await eventually(
+        async () => {
+          const info = await client.flowControl.get(flowControlKey);
+          expect(info.rateCount).toBe(0);
+        },
+        { timeout: 15_000, interval: 1000 }
+      );
 
       // Clean up
       // eslint-disable-next-line @typescript-eslint/no-deprecated

--- a/src/client/flow-control.test.ts
+++ b/src/client/flow-control.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, test } from "bun:test";
 import { Client } from "./client";
 import { MOCK_QSTASH_SERVER_URL, mockQStashServer, expectToReject } from "./workflow/test-utils";
-import { eventually } from "./logs.test";
+import { eventually } from "./test-utils";
 
 describe("FlowControl empty id guard", () => {
   test("should not send request when get is called with an empty string", async () => {

--- a/src/client/flow-control.test.ts
+++ b/src/client/flow-control.test.ts
@@ -210,12 +210,15 @@ describe("FlowControl", () => {
         },
       });
 
-      // Reset the rate
-      await client.flowControl.resetRate(flowControlKey);
+      // Pause delivery so in-flight dispatches don't keep consuming the rate
+      // after we reset it (otherwise rateCount creeps back up).
+      await client.flowControl.pause(flowControlKey);
 
-      // Verify rate was reset by checking the flow control info
+      // Reset the rate and verify it was cleared. We reset inside the retry loop
+      // so the reset takes effect even if the pause/reset are eventually consistent.
       await eventually(
         async () => {
+          await client.flowControl.resetRate(flowControlKey);
           const info = await client.flowControl.get(flowControlKey);
           expect(info.rateCount).toBe(0);
         },

--- a/src/client/logs.test.ts
+++ b/src/client/logs.test.ts
@@ -261,10 +261,10 @@ describe("logs - mocked filter url shape", () => {
         url: `${MOCK_QSTASH_SERVER_URL}/v2/events?url=${encodeURIComponent("https://a.com")}&url=${encodeURIComponent("https://b.com")}&host=a.com&host=b.com&path=%2Fwebhook`,
       },
       validateRequest: (request) => {
-        const params = new URL(request.url).searchParams;
-        expect(params.getAll("url")).toEqual(["https://a.com", "https://b.com"]);
-        expect(params.getAll("host")).toEqual(["a.com", "b.com"]);
-        expect(params.getAll("path")).toEqual(["/webhook"]);
+        const parameters = new URL(request.url).searchParams;
+        expect(parameters.getAll("url")).toEqual(["https://a.com", "https://b.com"]);
+        expect(parameters.getAll("host")).toEqual(["a.com", "b.com"]);
+        expect(parameters.getAll("path")).toEqual(["/webhook"]);
       },
     });
   });

--- a/src/client/logs.test.ts
+++ b/src/client/logs.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from "bun:test";
 import { Client } from "./client";
 import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "./workflow/test-utils";
+import { eventually } from "./test-utils";
 
 describe("logs", () => {
   test(
@@ -293,31 +294,3 @@ describe("events (deprecated)", () => {
   });
 });
 
-const EVENTUALLY_TIMEOUT = 5000;
-
-export const eventually = async function (
-  function_: () => Promise<void> | void,
-  options: {
-    timeout?: number;
-    interval?: number;
-  } = {}
-): Promise<void> {
-  const { timeout = EVENTUALLY_TIMEOUT, interval = 100 } = options;
-
-  const startTime = Date.now();
-
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  while (true) {
-    try {
-      await function_();
-      // Success case - all assertions passed
-      return;
-    } catch (error) {
-      const lastError = error as Error;
-      if (Date.now() - startTime >= timeout) {
-        throw new Error(`Assertions not satisfied within timeout: ${lastError.message}`);
-      }
-      await new Promise((resolve) => setTimeout(resolve, interval));
-    }
-  }
-};

--- a/src/client/logs.test.ts
+++ b/src/client/logs.test.ts
@@ -293,4 +293,3 @@ describe("events (deprecated)", () => {
     expect(Array.isArray(result.events)).toBe(true);
   });
 });
-

--- a/src/client/logs.test.ts
+++ b/src/client/logs.test.ts
@@ -101,6 +101,74 @@ describe("logs", () => {
     { timeout: 15_000 }
   );
 
+  test(
+    "should filter logs by multiple urls (OR semantics)",
+    async () => {
+      const stamp = Date.now();
+      const urlA = `https://example.com/log-url-a-${stamp}`;
+      const urlB = `https://example.com/log-url-b-${stamp}`;
+      const urlC = `https://example.com/log-url-c-${stamp}`;
+
+      const { messageId: idA } = await client.publish({ url: urlA, body: "url-or-a" });
+      const { messageId: idB } = await client.publish({ url: urlB, body: "url-or-b" });
+      const { messageId: idC } = await client.publish({ url: urlC, body: "url-or-c" });
+
+      // filtering by [A, B] should match A and B but NOT C.
+      await eventually(
+        async () => {
+          const result = await client.logs({ filter: { url: [urlA, urlB] } });
+          const ids = new Set(result.logs.map((l) => l.messageId));
+          expect(ids.has(idA)).toBe(true);
+          expect(ids.has(idB)).toBe(true);
+          expect(ids.has(idC)).toBe(false);
+        },
+        { interval: 1000 }
+      );
+    },
+    { timeout: 15_000 }
+  );
+
+  test(
+    "should filter logs by destination host and path",
+    async () => {
+      const stamp = Date.now();
+      const comPath = `/log-host-com-${stamp}`;
+      const orgPath = `/log-host-org-${stamp}`;
+
+      const { messageId: comId } = await client.publish({
+        url: `https://example.com${comPath}`,
+        body: "host-com",
+      });
+      const { messageId: orgId } = await client.publish({
+        url: `https://example.org${orgPath}`,
+        body: "host-org",
+      });
+
+      // host discriminates: filtering host example.org excludes the example.com message.
+      await eventually(
+        async () => {
+          const byHost = await client.logs({ filter: { host: "example.org" } });
+          const ids = new Set(byHost.logs.map((l) => l.messageId));
+          expect(ids.has(orgId)).toBe(true);
+          expect(ids.has(comId)).toBe(false);
+        },
+        { interval: 1000 }
+      );
+
+      // path discriminates: filtering the unique example.com path excludes the example.org message.
+      await eventually(
+        async () => {
+          const byPath = await client.logs({ filter: { path: comPath } });
+          const ids = new Set(byPath.logs.map((l) => l.messageId));
+          expect(ids.has(comId)).toBe(true);
+          expect(ids.has(orgId)).toBe(false);
+        },
+        { interval: 1000 }
+      );
+    },
+    { timeout: 15_000 }
+  );
+
   test("should use cursor", async () => {
     await client.logs({
       filter: {
@@ -170,6 +238,33 @@ describe("logs - mocked filter url shape", () => {
       },
       validateRequest: (request) => {
         expect(new URL(request.url).searchParams.getAll("label")).toEqual(["label-1", "label-2"]);
+      },
+    });
+  });
+
+  test("should send multi-value url and host/path filters as repeated query params", async () => {
+    const client = new Client({ token, baseUrl: MOCK_QSTASH_SERVER_URL });
+    await mockQStashServer({
+      execute: async () => {
+        await client.logs({
+          filter: {
+            url: ["https://a.com", "https://b.com"],
+            host: ["a.com", "b.com"],
+            path: "/webhook",
+          },
+        });
+      },
+      responseFields: { body: { events: [] }, status: 200 },
+      receivesRequest: {
+        method: "GET",
+        token,
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/events?url=${encodeURIComponent("https://a.com")}&url=${encodeURIComponent("https://b.com")}&host=a.com&host=b.com&path=%2Fwebhook`,
+      },
+      validateRequest: (request) => {
+        const params = new URL(request.url).searchParams;
+        expect(params.getAll("url")).toEqual(["https://a.com", "https://b.com"]);
+        expect(params.getAll("host")).toEqual(["a.com", "b.com"]);
+        expect(params.getAll("path")).toEqual(["/webhook"]);
       },
     });
   });

--- a/src/client/messages.test.ts
+++ b/src/client/messages.test.ts
@@ -256,6 +256,79 @@ describe("Messages", () => {
   );
 
   test(
+    "should cancel messages by multiple flowControlKeys (OR semantics)",
+    async () => {
+      const keyA = `cancel-multi-fc-a-${Date.now()}`;
+      const keyB = `cancel-multi-fc-b-${Date.now()}`;
+      const keyC = `cancel-multi-fc-c-${Date.now()}`;
+
+      for (const key of [keyA, keyB, keyC]) {
+        await client.publish({
+          url: "https://httpbin.org/status/200",
+          body: "hello",
+          delay: "10d",
+          flowControl: { key, parallelism: 1 },
+        });
+      }
+
+      // Cancelling [A, B] should match the A and B messages but NOT C.
+      const result = await client.messages.cancel({
+        filter: { flowControlKey: [keyA, keyB] },
+      });
+      expect(result.cancelled).toBe(2);
+
+      // C survived and can still be cancelled on its own.
+      const remaining = await client.messages.cancel({ filter: { flowControlKey: keyC } });
+      expect(remaining.cancelled).toBe(1);
+    },
+    { timeout: 20_000 }
+  );
+
+  test(
+    "should cancel messages by destination path (single and multi-value)",
+    async () => {
+      const stamp = Date.now();
+      const pathA = `/cancel-path-a-${stamp}`;
+      const pathB = `/cancel-path-b-${stamp}`;
+      const pathC = `/cancel-path-c-${stamp}`;
+
+      for (const path of [pathA, pathB, pathC]) {
+        await client.publish({ url: `https://example.com${path}`, body: "hello", delay: "10d" });
+      }
+
+      // Unique paths make this deterministic: [A, B] cancels exactly two.
+      const result = await client.messages.cancel({ filter: { path: [pathA, pathB] } });
+      expect(result.cancelled).toBe(2);
+
+      // C is untouched and matched by its own path.
+      const remaining = await client.messages.cancel({ filter: { path: pathC } });
+      expect(remaining.cancelled).toBe(1);
+    },
+    { timeout: 20_000 }
+  );
+
+  test(
+    "should cancel messages by destination host (host discriminates)",
+    async () => {
+      const stamp = Date.now();
+      const comPath = `/cancel-host-com-${stamp}`;
+      const orgPath = `/cancel-host-org-${stamp}`;
+
+      await client.publish({ url: `https://example.com${comPath}`, body: "hello", delay: "10d" });
+      await client.publish({ url: `https://example.org${orgPath}`, body: "hello", delay: "10d" });
+
+      // Cancelling host example.org must not touch the example.com message.
+      const orgResult = await client.messages.cancel({ filter: { host: "example.org" } });
+      expect(orgResult.cancelled).toBeGreaterThanOrEqual(1);
+
+      // The example.com message survived — proven by cancelling it via its path.
+      const comResult = await client.messages.cancel({ filter: { path: comPath } });
+      expect(comResult.cancelled).toBe(1);
+    },
+    { timeout: 20_000 }
+  );
+
+  test(
     "should respect count: 1 with all: true",
     async () => {
       await client.batchJSON([

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -181,6 +181,11 @@ export class Messages {
    * - A filter object: `cancel({ filter: { flowControlKey: "key", label: "label" } })`
    * - All messages: `cancel({ all: true })`
    *
+   * Filters support multiple values: pass an array to match a message whose value
+   * equals any of the given values (OR logic). Separate filters are combined with
+   * AND logic. For example:
+   * `cancel({ filter: { url: ["https://a.com", "https://b.com"], host: "a.com" } })`
+   *
    * Pass `count` to limit the number of messages processed per call (defaults to 100).
    * Call in a loop until `cancelled` is 0:
    *

--- a/src/client/schedules.test.ts
+++ b/src/client/schedules.test.ts
@@ -310,6 +310,37 @@ describe("Schedules", () => {
       },
     });
   });
+
+  test("should create schedule with multiple labels", async () => {
+    const qstashToken = nanoid();
+
+    const client = new Client({
+      baseUrl: MOCK_QSTASH_SERVER_URL,
+      token: qstashToken,
+    });
+    await mockQStashServer({
+      execute: async () => {
+        await client.schedules.create({
+          scheduleId: "test-labels",
+          destination: MOCK_SERVER_URL,
+          cron: "* * * * 1",
+          label: ["label-1", "label-2"],
+        });
+      },
+      responseFields: {
+        body: { scheduleId: "test-labels" },
+        status: 200,
+      },
+      receivesRequest: {
+        method: "POST",
+        token: qstashToken,
+        url: "http://localhost:8080/v2/schedules/https://requestcatcher.com/",
+        headers: {
+          "upstash-label": "label-1,label-2",
+        },
+      },
+    });
+  });
 });
 
 describe("Schedules empty id guard", () => {

--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-deprecated */
-import { assertNonEmptyId, prefixHeaders, wrapWithGlobalHeaders } from "./utils";
+import { assertNonEmptyId, prefixHeaders, serializeLabel, wrapWithGlobalHeaders } from "./utils";
 import type { Requester } from "./http";
 import type { BodyInit, FlowControl, HeadersInit, HTTPMethods } from "./types";
 import type { Duration } from "./duration";
@@ -45,8 +45,18 @@ export type Schedule = {
 
   /**
    * The label assigned to the schedule for filtering purposes.
+   *
+   * @deprecated Use `labels` instead. When a schedule has multiple labels, this
+   *   field only contains the first one.
    */
   label?: string;
+
+  /**
+   * The labels assigned to the schedule for filtering purposes.
+   *
+   * A schedule can have multiple labels when created with `label: string[]`.
+   */
+  labels?: string[];
 
   /**
    * The timestamp of the last scheduled execution.
@@ -177,11 +187,14 @@ export type CreateScheduleRequest = {
   flowControl?: FlowControl;
 
   /**
-   * Assign a label to the schedule to filter logs later.
+   * Assign one or more labels to the schedule to filter logs later.
+   *
+   * Pass an array to attach multiple labels to a single schedule; they are sent
+   * as a comma-separated value in the `Upstash-Label` header.
    *
    * @default undefined
    */
-  label?: string;
+  label?: string | string[];
 
   /**
    * Configure which fields should be redacted in logs.
@@ -293,7 +306,7 @@ export class Schedules {
     }
 
     if (request.label !== undefined) {
-      headers.set("Upstash-Label", request.label);
+      headers.set("Upstash-Label", serializeLabel(request.label));
     }
 
     if (request.redact !== undefined) {

--- a/src/client/test-utils.ts
+++ b/src/client/test-utils.ts
@@ -1,0 +1,28 @@
+const EVENTUALLY_TIMEOUT = 5000;
+
+export const eventually = async function (
+  function_: () => Promise<void> | void,
+  options: {
+    timeout?: number;
+    interval?: number;
+  } = {}
+): Promise<void> {
+  const { timeout = EVENTUALLY_TIMEOUT, interval = 100 } = options;
+
+  const startTime = Date.now();
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  while (true) {
+    try {
+      await function_();
+      // Success case - all assertions passed
+      return;
+    } catch (error) {
+      const lastError = error as Error;
+      if (Date.now() - startTime >= timeout) {
+        throw new Error(`Assertions not satisfied within timeout: ${lastError.message}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+  }
+};

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -6,7 +6,7 @@ import {
   serializeLabel,
 } from "./utils";
 import { describe, expect, test } from "bun:test";
-import type { DLQBulkActionFilters } from "./filter-types";
+import type { DLQBulkActionFilters, MessageCancelFilters } from "./filter-types";
 
 describe("prefixHeaders", () => {
   test("should keep headers starting with upstash as they are - Upstash-", () => {
@@ -79,6 +79,42 @@ describe("buildFilterPayload", () => {
     const request: DLQBulkActionFilters = { filter: { callerIp: "1.2.3.4" } };
     const result = buildBulkActionFilterPayload(request);
     expect(result).toHaveProperty("callerIp", "1.2.3.4");
+  });
+
+  test("should pass multi-value cancel filters through as arrays", () => {
+    const request: MessageCancelFilters = {
+      filter: {
+        url: ["https://a.com", "https://b.com"],
+        callerIp: ["1.2.3.4", "5.6.7.8"],
+        flowControlKey: ["key-1", "key-2"],
+        scheduleId: ["scd_1", "scd_2"],
+        queueName: ["queue-1", "queue-2"],
+      },
+    };
+    const result = buildBulkActionFilterPayload(request);
+    expect(result).toHaveProperty("url", ["https://a.com", "https://b.com"]);
+    expect(result).toHaveProperty("callerIp", ["1.2.3.4", "5.6.7.8"]);
+    expect(result).toHaveProperty("flowControlKey", ["key-1", "key-2"]);
+    expect(result).toHaveProperty("scheduleId", ["scd_1", "scd_2"]);
+    expect(result).toHaveProperty("queueName", ["queue-1", "queue-2"]);
+  });
+
+  test("should rename multi-value urlGroup to topicName", () => {
+    const request: MessageCancelFilters = {
+      filter: { urlGroup: ["group-1", "group-2"] },
+    };
+    const result = buildBulkActionFilterPayload(request);
+    expect(result).toHaveProperty("topicName", ["group-1", "group-2"]);
+    expect(result).not.toHaveProperty("urlGroup");
+  });
+
+  test("should pass host and path cancel filters through", () => {
+    const request: MessageCancelFilters = {
+      filter: { host: ["a.com", "b.com"], path: "/webhook" },
+    };
+    const result = buildBulkActionFilterPayload(request);
+    expect(result).toHaveProperty("host", ["a.com", "b.com"]);
+    expect(result).toHaveProperty("path", "/webhook");
   });
 });
 

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -286,7 +286,7 @@ export function buildBulkActionFilterPayload(request: DLQBulkActionFilters | Mes
   // Filter branch
   const count = "count" in request ? request.count ?? DEFAULT_BULK_COUNT : DEFAULT_BULK_COUNT;
   return {
-    ...renameUrlGroup(request.filter as Record<string, unknown> & { urlGroup?: string }),
+    ...renameUrlGroup(request.filter as Record<string, unknown> & { urlGroup?: string | string[] }),
     count,
     cursor,
   };
@@ -295,9 +295,9 @@ export function buildBulkActionFilterPayload(request: DLQBulkActionFilters | Mes
 /**
  * Renames `urlGroup` to `topicName` in a filter object.
  */
-export function renameUrlGroup<T extends { urlGroup?: string; api?: string }>(
+export function renameUrlGroup<T extends { urlGroup?: string | string[]; api?: string }>(
   filter: T
-): Omit<T, "urlGroup" | "api"> & { topicName?: string } {
+): Omit<T, "urlGroup" | "api"> & { topicName?: string | string[] } {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { urlGroup, api, ...rest } = filter;
   return { ...rest, ...(urlGroup === undefined ? {} : { topicName: urlGroup }) };


### PR DESCRIPTION
https://linear.app/upstash/issue/DX-2825/qstashworkflow-multi-value-cancel-etc

Add multi-value filter support to the bulk message cancel endpoint and multi-label support to schedules, mirroring the QStash API changes.

Bulk message cancel (`messages.cancel({ filter })`):
- `url`, `urlGroup`, `queueName`, `scheduleId`, `flowControlKey` and `callerIp` filters now accept `string | string[]`. A message matches if its value equals any of the given values (OR logic); separate filters are combined with AND logic.
- Add new `host` and `path` filters (destination URL host/path), each supporting multiple values.
- `renameUrlGroup` handles array `urlGroup` values when mapping to `topicName`.

Schedules (`schedules.create`):
- `label` accepts `string | string[]`; arrays are sent as a comma-separated `Upstash-Label` header. Added `labels` to the `Schedule` type and deprecated the singular `label`.

Tests added for multi-value filter pass-through (incl. host/path and urlGroup→topicName) and multi-label schedule creation.