### PR TITLE
fix: don't retry when retry is disabled

### DIFF
--- a/src/client/http.test.ts
+++ b/src/client/http.test.ts
@@ -1,6 +1,35 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 import { describe, test, expect } from "bun:test";
 import { Client } from "./client";
+import { HttpClient } from "./http";
+
+const countFetchCalls = async (retry: false | { retries: number }) => {
+  let fetchCalls = 0;
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (() => {
+    fetchCalls += 1;
+    return Promise.reject(new Error(`forced network failure ${fetchCalls}`));
+  }) as typeof fetch;
+
+  const client = new HttpClient({
+    baseUrl: "https://example.com",
+    authorization: "Bearer test-token",
+    retry,
+    devMode: false,
+  });
+
+  try {
+    await client.request({ method: "GET", path: ["v2", "messages", "msg_123"] });
+    throw new Error("expected request to throw");
+  } catch {
+    // request is expected to fail
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  return fetchCalls;
+};
 
 describe("http", () => {
   test("should terminate after sleeping 5 times", () => {
@@ -21,5 +50,13 @@ describe("http", () => {
 
     // if the Promise.race doesn't throw, that means the retries took longer than 4.5s
     expect(throws).toThrow("Was there a typo in the url or port?");
+  });
+
+  test("should call fetch exactly once when retry is disabled", async () => {
+    expect(await countFetchCalls(false)).toBe(1);
+  });
+
+  test("should call fetch twice when retries is 1", async () => {
+    expect(await countFetchCalls({ retries: 1 })).toBe(2);
   });
 });

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -119,7 +119,7 @@ export class HttpClient implements Requester {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       typeof config.retry === "boolean" && !config.retry
         ? {
-            attempts: 1,
+            attempts: 0,
             backoff: () => 0,
           }
         : {


### PR DESCRIPTION
Fixes #272

### Summary

When `HttpClient` was configured with `retry: false`, a failing request still called `fetch` twice instead of once. The `retry: false` branch normalized to `attempts: 1`, but since #207 the request loop treats `attempts` as the number of retries *after* the initial attempt (`index <= attempts`), so `1` meant "one extra retry" rather than "one total attempt".

### Changes

- Normalize `retry: false` to `attempts: 0` in `src/client/http.ts`, so a disabled-retry client performs exactly one fetch attempt. Object-form semantics (`{ retries: N }` → N retries after the initial attempt) are unchanged.

- Add tests covering both cases: `retry: false` calls `fetch` exactly once, and `{ retries: 1 }` calls it twice.

### Testing

`bun test src/client/http.test.ts` — 3 pass, 0 fail (new tests plus the existing backoff-timing test).
