### PR TITLE
DX-2588: multi-value responseStatus filter on DLQ bulk actions

### DIFF
--- a/src/client/dlq.test.ts
+++ b/src/client/dlq.test.ts
@@ -1117,4 +1117,22 @@ describe("DLQ - mocked filter url shape", () => {
       },
     });
   });
+
+  test("should send multi-value responseStatus as repeated query params", async () => {
+    const mockClient = new Client({ token, baseUrl: MOCK_QSTASH_SERVER_URL });
+    await mockQStashServer({
+      execute: async () => {
+        await mockClient.dlq.delete({ filter: { responseStatus: [500, 503] } });
+      },
+      responseFields: { body: { deleted: 0 }, status: 200 },
+      receivesRequest: {
+        method: "DELETE",
+        token,
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/dlq?responseStatus=500&responseStatus=503&count=100`,
+      },
+      validateRequest: (request) => {
+        expect(new URL(request.url).searchParams.getAll("responseStatus")).toEqual(["500", "503"]);
+      },
+    });
+  });
 });

--- a/src/client/filter-types.ts
+++ b/src/client/filter-types.ts
@@ -55,7 +55,12 @@ type QStashIdentityFields = {
 
 /** DLQ-specific response filter. */
 type DLQResponseFields = {
-  responseStatus?: number;
+  /**
+   * Filter by the response status code of the last delivery attempt.
+   * Supports multiple values: pass an array to match any of the given
+   * status codes (OR semantics).
+   */
+  responseStatus?: number | number[];
 };
 
 /** Logs-specific filter fields exclusive to log endpoints. */

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -38,7 +38,7 @@ export type UpstashRequest = {
    */
   method?: HTTPMethods;
 
-  query?: Record<string, string | number | boolean | Date | string[] | undefined>;
+  query?: Record<string, string | number | boolean | Date | string[] | number[] | undefined>;
 
   /**
    * if enabled, call `res.json()`
@@ -238,7 +238,7 @@ export class HttpClient implements Requester {
             throw new QstashEmptyArrayError(key);
           }
           for (const item of value) {
-            url.searchParams.append(key, item);
+            url.searchParams.append(key, item.toString());
           }
         } else if (value instanceof Date) {
           url.searchParams.set(key, value.getTime().toString());


### PR DESCRIPTION
The server takes `responseStatus` as a repeated query param, the SDK only allowed one value.

- `responseStatus?: number | number[]` on DLQ filters
- HTTP query type widened to accept `number[]`

Related: upstash/workflow-js#208